### PR TITLE
Using RecursiveArrayTools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,9 @@
 *.bbl
 *.blg
 *.log
+*.DS_Store
 
 
 docs/build/
 docs/site/
+docs/Manifest.toml

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ os:
   - linux
   - osx
 julia:
+  - 1.0
   - 1.1
   - nightly
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,7 @@ os:
   - linux
   - osx
 julia:
-  - 0.7
-  - 1.0
+  - 1.1
   - nightly
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,14 @@ notifications:
 after_success:
   - julia -e 'using Pkg; cd(Pkg.dir("AbstractOperators")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(process_folder())'
   - julia -e 'using Pkg; cd(Pkg.dir("AbstractOperators")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
-  - julia -e 'using Pkg; Pkg.add("Documenter")'
-  - julia -e 'using Pkg; cd(Pkg.dir("AbstractOperators")); include(joinpath("docs", "make.jl"))'
+
+jobs:
+  include:
+    - stage: "Documentation"
+      julia: 1.1
+      os: linux
+      script:
+        - juliadev --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd()));
+                                               Pkg.instantiate()'
+        - juliadev --project=docs/ docs/make.jl
+      after_success: skip

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ jobs:
       julia: 1.1
       os: linux
       script:
-        - juliadev --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd()));
+        - julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd()));
                                                Pkg.instantiate()'
-        - juliadev --project=docs/ docs/make.jl
+        - julia --project=docs/ docs/make.jl
       after_success: skip

--- a/README.md
+++ b/README.md
@@ -73,17 +73,19 @@ julia> H = [A B]
 
 In this case `H` has a domain of dimensions `size(H,2) = ((3, 4), (3, 4))` and type `domainType(H) = (Float64, Complex{Float64})`.
 
-When an `AbstractOperators` have multiple domains, this must be multiplied using a `Tuple`s of `AbstractArray`s with corresponding `size(H,2)` and `domainType(H)`, for example: 
+When an `AbstractOperators` have multiple domains, this must be multiplied using an `ArrayPartition` (see [RecursiveArrayTools](https://github.com/JuliaDiffEq/RecursiveArrayTools.jl/]) with corresponding size and domain, for example: 
 
 ```julia
-julia> H*(x, complex(x))
+julia> using RecursiveArrayTools
+
+julia> H*ArrayPartition(x, complex(x))
 3×4 Array{Complex{Float64},2}:
  -16.3603+0.0im      52.4946-8.69342im  -129.014+0.0im      44.6712+8.69342im
   -22.051+23.8135im  16.5309-10.9601im  -22.5719+39.5599im  13.8174+3.81678im
  -5.81874-23.8135im  9.70679-3.81678im  -2.21552-39.5599im  11.5502+10.9601im
 ```
 
-Similarly, when an `AbstractOperators` have multiple codomains, this will return a `Tuple` of `AbstractArray`s with corresponding `size(H,1)` and `codomainType(H)`, for example: 
+Similarly, when an `AbstractOperators` have multiple codomains, this will return an `ArrayPartition`, for example: 
 ```julia
 julia> V = VCAT(Eye(3,3),FiniteDiff((3,3)))
 [I;δx]  ℝ^(3, 3) -> ℝ^(3, 3)  ℝ^(2, 3)

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,5 @@
 julia 0.7
-AbstractFFTs v0.3.2
-FFTW 0.2.4
-DSP 0.5.1
+AbstractFFTs v0.3
+FFTW 0.2
+DSP 0.5
+RecursiveArrayTools 0.18

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.7
+julia 1.0
 AbstractFFTs v0.3
 FFTW 0.2
 DSP 0.5

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,6 @@
 environment:
   matrix:
+  - julia_version: 1.0
   - julia_version: 1.1
   - julia_version: nightly
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,6 @@
 environment:
   matrix:
-  - julia_version: 0.7
-  - julia_version: 1
+  - julia_version: 1.1
   - julia_version: nightly
 
 platform:
@@ -10,7 +9,6 @@ platform:
 
 matrix:
   allow_failures:
-  - julia_version: 1
   - julia_version: nightly
 
 branches:

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,0 +1,2 @@
+[deps]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -2,10 +2,10 @@ using Documenter, AbstractOperators
 
 makedocs(
   modules = [AbstractOperators],
-  format = :html,
+  format = Documenter.HTML(),
   sitename = "AbstractOperators.jl",
   authors = "Niccolò Antonello and Lorenzo Stella",
-  pages = Any[
+  pages = [
   "Home"               => "index.md",
   "Abstract Operators" => "operators.md",
   "Calculus rules"     => "calculus.md",
@@ -15,9 +15,5 @@ makedocs(
 
 deploydocs(
   repo   = "github.com/kul-forbes/AbstractOperators.jl.git",
-  julia  = "0.6",
-  osname = "linux",
   target = "build",
-  deps = nothing,
-  make = nothing,
 )

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,5 +1,12 @@
 # AbstractOperators.jl
 
+[![Build Status](https://travis-ci.org/kul-forbes/AbstractOperators.jl.svg?branch=master)](https://travis-ci.org/kul-forbes/AbstractOperators.jl)
+[![Build status](https://ci.appveyor.com/api/projects/status/lfrmkg2s1awyxtk8/branch/master?svg=true)](https://ci.appveyor.com/project/nantonel/abstractoperators-jl/branch/master)
+[![codecov](https://codecov.io/gh/kul-forbes/AbstractOperators.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/kul-forbes/AbstractOperators.jl)
+
+[![](https://img.shields.io/badge/docs-stable-blue.svg)](https://kul-forbes.github.io/AbstractOperators.jl/stable)
+[![](https://img.shields.io/badge/docs-latest-blue.svg)](https://kul-forbes.github.io/AbstractOperators.jl/latest)
+
 ## Description
 
 Abstract operators extend the syntax typically used for matrices to linear mappings of arbitrary dimensions and nonlinear functions. Unlike matrices however, abstract operators apply the mappings with specific efficient algorithms that minimize memory requirements. 
@@ -66,17 +73,19 @@ julia> H = [A B]
 
 In this case `H` has a domain of dimensions `size(H,2) = ((3, 4), (3, 4))` and type `domainType(H) = (Float64, Complex{Float64})`.
 
-When an `AbstractOperators` have multiple domains, this must be multiplied using a `Tuple`s of `AbstractArray`s with corresponding `size(H,2)` and `domainType(H)`, for example: 
+When an `AbstractOperators` have multiple domains, this must be multiplied using an `ArrayPartition` (see [RecursiveArrayTools](https://github.com/JuliaDiffEq/RecursiveArrayTools.jl/]) with corresponding size and domain, for example: 
 
 ```julia
-julia> H*(x, complex(x))
+julia> using RecursiveArrayTools
+
+julia> H*ArrayPartition(x, complex(x))
 3×4 Array{Complex{Float64},2}:
  -16.3603+0.0im      52.4946-8.69342im  -129.014+0.0im      44.6712+8.69342im
   -22.051+23.8135im  16.5309-10.9601im  -22.5719+39.5599im  13.8174+3.81678im
  -5.81874-23.8135im  9.70679-3.81678im  -2.21552-39.5599im  11.5502+10.9601im
 ```
 
-Similarly, when an `AbstractOperators` have multiple codomains, this will return a `Tuple` of `AbstractArray`s with corresponding `size(H,1)` and `codomainType(H)`, for example: 
+Similarly, when an `AbstractOperators` have multiple codomains, this will return an `ArrayPartition`, for example: 
 ```julia
 julia> V = VCAT(Eye(3,3),FiniteDiff((3,3)))
 [I;δx]  ℝ^(3, 3) -> ℝ^(3, 3)  ℝ^(2, 3)

--- a/src/AbstractOperators.jl
+++ b/src/AbstractOperators.jl
@@ -2,12 +2,9 @@ __precompile__()
 
 module AbstractOperators
 
-using LinearAlgebra, AbstractFFTs, DSP, FFTW
+using LinearAlgebra, AbstractFFTs, DSP, FFTW, RecursiveArrayTools
 
-# Block stuff
-include("utilities/block.jl")
-using AbstractOperators.BlockArrays
-
+const RealOrComplex{R} = Union{R, Complex{R}}
 abstract type AbstractOperator end
 
 abstract type LinearOperator    <: AbstractOperator end
@@ -22,7 +19,6 @@ export LinearOperator,
 # Predicates and properties
 
 include("properties.jl")
-
 include("calculus/AdjointOperator.jl")
 
 ## Linear operators

--- a/src/AbstractOperators.jl
+++ b/src/AbstractOperators.jl
@@ -4,6 +4,7 @@ module AbstractOperators
 
 using LinearAlgebra, AbstractFFTs, DSP, FFTW, RecursiveArrayTools
 
+
 const RealOrComplex{R} = Union{R, Complex{R}}
 abstract type AbstractOperator end
 
@@ -15,6 +16,8 @@ import LinearAlgebra: mul!
 export LinearOperator,
        NonLinearOperator,
        AbstractOperator
+# from other packages
+export ArrayPartition, mul!
 
 # Predicates and properties
 

--- a/src/AbstractOperators.jl
+++ b/src/AbstractOperators.jl
@@ -16,7 +16,6 @@ import LinearAlgebra: mul!
 export LinearOperator,
        NonLinearOperator,
        AbstractOperator
-# from other packages
 export mul!
 
 # Predicates and properties

--- a/src/AbstractOperators.jl
+++ b/src/AbstractOperators.jl
@@ -17,7 +17,7 @@ export LinearOperator,
        NonLinearOperator,
        AbstractOperator
 # from other packages
-export ArrayPartition, mul!
+export mul!
 
 # Predicates and properties
 

--- a/src/calculus/DCAT.jl
+++ b/src/calculus/DCAT.jl
@@ -62,9 +62,12 @@ function DCAT(A::Vararg{AbstractOperator})
 end
 
 # Mappings
-@generated function mul!(y, H::DCAT{N,L,P1,P2}, b) where {N,L,P1,P2} 
+@generated function mul!(yy::ArrayPartition, 
+                         H::DCAT{N,L,P1,P2}, 
+                         bb::ArrayPartition) where {N,L,P1,P2} 
 
-	ex = :()
+  # extract stuff
+	ex = :(y = yy.x; b = bb.x )
 
 	for i = 1:N
 
@@ -98,9 +101,12 @@ end
 
 end
 
-@generated function mul!(y, A::AdjointOperator{DCAT{N,L,P1,P2}}, b) where {N,L,P1,P2} 
+@generated function mul!(yy::ArrayPartition, 
+                         A::AdjointOperator{DCAT{N,L,P1,P2}},
+                         bb::ArrayPartition) where {N,L,P1,P2} 
 
-	ex = :(H = A.A)
+  # extract stuff
+	ex = :(H = A.A; y = yy.x; b = bb.x )
 
 	for i = 1:N
 
@@ -196,7 +202,7 @@ remove_displacement(D::DCAT) = DCAT(remove_displacement.(D.A), D.idxD, D.idxC)
 
 # special cases
 # Eye constructor
-Eye(x::A) where {N, A <: NTuple{N,AbstractArray}} = DCAT(Eye.(x)...)
+Eye(x::ArrayPartition) = DCAT(Eye.(x.x)...)
 diag(L::DCAT{N,NTuple{N,E}}) where {N, E <: Eye} = 1.
 diag_AAc(L::DCAT{N,NTuple{N,E}}) where {N, E <: Eye} = 1.
 diag_AcA(L::DCAT{N,NTuple{N,E}}) where {N, E <: Eye} = 1.

--- a/src/calculus/DCAT.jl
+++ b/src/calculus/DCAT.jl
@@ -79,7 +79,7 @@ end
 		# stacked operator 
 		# build mul!(( y[H.idxC[i][1]], y[H.idxC[i][2]] ...  ), H.A[i], b)
         yy =  [ :(y[H.idxC[$i][$ii]]) for ii in eachindex(fieldnames(fieldtype(P2,i)))]
-        yy = :( tuple( $(yy...) ) )
+        yy = :( ArrayPartition( $(yy...) ) )
 		end
 
 		if fieldtype(P1,i) <: Int 
@@ -90,7 +90,7 @@ end
 		# stacked operator 
 		# build mul!(H.buf, H.A[i],( b[H.idxD[i][1]], b[H.idxD[i][2]] ...  ))
         bb = [ :(b[H.idxD[$i][$ii]]) for ii in eachindex(fieldnames(fieldtype(P1,i))) ]
-        bb = :( tuple( $(bb...) ) )
+        bb = :( ArrayPartition( $(bb...) ) )
 		end
 		
 		ex = :($ex; mul!($yy,H.A[$i],$bb))
@@ -118,7 +118,7 @@ end
 		# stacked operator 
 		# build mul!(( y[H.idxD[i][1]], y[H.idxD[i][2]] ...  ), H.A[i]', b)
         yy = [ :(y[H.idxD[$i][$ii]]) for ii in eachindex(fieldnames(fieldtype(P1,i)))]
-        yy = :( tuple( $(yy...) ))
+        yy = :( ArrayPartition( $(yy...) ))
 		end
 
 		if fieldtype(P2,i) <: Int 
@@ -129,7 +129,7 @@ end
 		# stacked operator 
 		# build mul!(H.buf, H.A[i]',( b[H.idxC[i][1]], b[H.idxC[i][2]] ...  ))
         bb = [ :(b[H.idxC[$i][$ii]]) for ii in eachindex(fieldnames(fieldtype(P2,i)))]
-        bb = :( tuple( $(bb...) ) )
+        bb = :( ArrayPartition( $(bb...) ) )
 		end
 		
 		ex = :($ex; mul!($yy,H.A[$i]',$bb))

--- a/src/calculus/DCAT.jl
+++ b/src/calculus/DCAT.jl
@@ -16,7 +16,7 @@ DCAT  ℝ^10  ℝ^10  ℝ^(4, 4) -> ℝ^10  ℝ^10  ℝ^(3, 4)
 To evaluate `DCAT` operators multiply them with a `Tuple` of `AbstractArray` of the correct domain size and type. The output will consist as well of a `Tuple` with the codomain type and size of the `DCAT`.
 
 ```julia
-julia> D*(ones(2),ones(2),ones(3))
+julia> D*ArrayPartition(ones(2),ones(2),ones(3))
 ([2.0, 2.0], Complex{Float64}[3.0+0.0im, 0.0+0.0im, 0.0+0.0im])
 
 ```

--- a/src/calculus/HCAT.jl
+++ b/src/calculus/HCAT.jl
@@ -15,21 +15,23 @@ Horizontally concatenate `AbstractOperator`s. Notice that all the operators must
 julia> HCAT(DFT(10),DCT(Complex{Float64},20)[1:10])
 [ℱ,↓*ℱc]  ℝ^10  ℂ^20 -> ℂ^10
 
-julia> H = [Eye(3) DiagOp(2*ones(3))]
-[I,╲]  ℝ^3  ℝ^3 -> ℝ^3
+julia> H = [Eye(10) DiagOp(2*ones(10))]
+[I,╲]  ℝ^10  ℝ^10 -> ℝ^10
 
 julia> hcat(H,DCT(10))
 HCAT  ℝ^10  ℝ^10  ℝ^10 -> ℝ^10
+
 ```
 
 To evaluate `HCAT` operators multiply them with a `Tuple` of `AbstractArray` of the correct dimensions and type. 
 
 ```julia
-julia> H*(ones(3),ones(3))
+julia> H*ArrayPartition(ones(10),ones(10))
 3-element Array{Float64,1}:
  3.0
  3.0
  3.0
+ ...
 ```
 
 """

--- a/src/calculus/HCAT.jl
+++ b/src/calculus/HCAT.jl
@@ -37,23 +37,22 @@ julia> H*(ones(3),ones(3))
 
 """
 struct HCAT{M, # number of codomains  
-	    N, # number of AbstractOperator 
-	    L <: NTuple{N,AbstractOperator},
-	    P <: NTuple{N,Union{Int,Tuple}},
-	    C <: Union{NTuple{M,AbstractArray}, AbstractArray},
-	    } <: AbstractOperator
+            N, # number of AbstractOperator 
+            L <: NTuple{N,AbstractOperator},
+            P <: NTuple{N,Union{Int,Tuple}},
+            C <: Union{NTuple{M,AbstractArray}, AbstractArray},
+           } <: AbstractOperator
 	A::L     # tuple of AbstractOperators
 	idxs::P  # indices 
 	         # H = HCAT(Eye(n),HCAT(Eye(n),Eye(n))) has H.idxs = (1,2,3) 
-		 # `AbstractOperators` are flatten
-	         # H = HCAT(Eye(n),Compose(MatrixOp(randn(n,n)),HCAT(Eye(n),Eye(n)))) 
-		 # has H.idxs = (1,(2,3))
-		 # `AbstractOperators` are stack
+           # `AbstractOperators` are flatten
+           # H = HCAT(Eye(n),Compose(MatrixOp(randn(n,n)),HCAT(Eye(n),Eye(n)))) 
+           # has H.idxs = (1,(2,3))
+           # `AbstractOperators` are stack
 	buf::C   # buffer memory
 end
 
 # Constructors
-
 function HCAT(A::L, idxs::P, buf::C, M::Int) where {N,  
 						    L <: NTuple{N,AbstractOperator},
 						    P <: NTuple{N,Union{Int,Tuple}},

--- a/src/calculus/HCAT.jl
+++ b/src/calculus/HCAT.jl
@@ -119,6 +119,9 @@ HCAT(A::AbstractOperator) = A
 
 # Mappings
 
+mul!(y::C, H::HCAT{M,N,L,P,C}, b::ArrayPartition) where {M,N,L,P,C} = mul!(y,H,b.x)
+mul!(y::ArrayPartition, H::HCAT{M,N,L,P,C}, b::ArrayPartition) where {M,N,L,P,C} = mul!(y.x,H,b.x)
+
 @generated function mul!(y::C, H::HCAT{M,N,L,P,C}, b::DD) where {M,N,L,P,C,DD}
 
 	ex = :()
@@ -165,6 +168,10 @@ HCAT(A::AbstractOperator) = A
 
 end
 
+mul!(y::ArrayPartition, A::AdjointOperator{HCAT{M,N,L,P,C}}, b::C) where {M,N,L,P,C} = mul!(y.x,A,b)
+mul!(y::ArrayPartition, A::AdjointOperator{HCAT{M,N,L,P,C}}, b::ArrayPartition) where {M,N,L,P,C} = 
+mul!(y.x,A,b.x)
+
 @generated function mul!(y::DD, A::AdjointOperator{HCAT{M,N,L,P,C}}, b::C) where {M,N,L,P,C,DD}
 
 	ex = :(H = A.A)
@@ -191,6 +198,11 @@ end
 end
 
 # same as mul! but skips `Zeros`
+mul_skipZeros!(y::C, H::HCAT{M,N,L,P,C}, b::ArrayPartition) where {M,N,L,P,C} =
+mul_skipZeros!(y,H,b.x)
+mul_skipZeros!(y::ArrayPartition, H::HCAT{M,N,L,P,C}, b::ArrayPartition) where {M,N,L,P,C} =
+mul_skipZeros!(y.x,H,b.x)
+
 @generated function mul_skipZeros!(y::C, H::HCAT{M,N,L,P,C}, b::DD) where {M,N,L,P,C,DD}
 
 	ex = :()
@@ -231,6 +243,11 @@ end
 end
 
 # same as mul! but skips `Zeros`
+mul_skipZeros!(y::ArrayPartition, A::AdjointOperator{HCAT{M,N,L,P,C}}, b::C) where {M,N,L,P,C} = 
+mul_skipZeros!(y.x,A,b)
+mul_skipZeros!(y::ArrayPartition, A::AdjointOperator{HCAT{M,N,L,P,C}}, b::ArrayPartition) where {M,N,L,P,C} = 
+mul_skipZeros!(y.x,A,b.x)
+
 @generated function mul_skipZeros!(y::DD, A::AdjointOperator{HCAT{M,N,L,P,C}}, b::C) where {M,N,L,P,C,DD}
 
 	ex = :(H = A.A)

--- a/src/calculus/HCAT.jl
+++ b/src/calculus/HCAT.jl
@@ -258,8 +258,8 @@ mul_skipZeros!(y.x,A,b.x)
 			if fieldtype(P,i) <: Int 
 				yy = :(y[H.idxs[$i]])
 			else
-                yy = [ :(y[H.idxs[$i][$ii]]) for ii in eachindex(fieldnames(fieldtype(P,i)))]
-                yy = :( tuple( $(yy...) ) )
+        yy = [ :(y[H.idxs[$i][$ii]]) for ii in eachindex(fieldnames(fieldtype(P,i)))]
+        yy = :( tuple( $(yy...) ) )
 			end
 			
 			ex = :($ex; mul!($yy,H.A[$i]',b))

--- a/src/calculus/Hadamard.jl
+++ b/src/calculus/Hadamard.jl
@@ -27,24 +27,24 @@ true
 
 ```
 """
-struct Hadamard{M, C, V <: VCAT{M}} <: NonLinearOperator
+struct Hadamard{C, V <: VCAT} <: NonLinearOperator
 	A::V
 	buf::C
 	buf2::C
-	function Hadamard(A::V, buf::C, buf2::C) where {M, C, V <: VCAT{M}}
+	function Hadamard(A::V, buf::C, buf2::C) where {C, V <: VCAT}
 		any([ai != size(A,1)[1] for ai in size(A,1)]) &&
 		throw(DimensionMismatch("cannot compose operators"))
 
-		new{M, C, V}(A,buf,buf2)
+		new{C, V}(A,buf,buf2)
 	end
 end
 
-struct HadamardJacobian{M, C, V <: VCAT{M}} <: LinearOperator
+struct HadamardJacobian{C, V <: VCAT} <: LinearOperator
 	A::V
 	buf::C
 	buf2::C
-	function HadamardJacobian(A::V,buf::C,buf2::C) where {M, C, V <: VCAT{M}}
-		new{M, C, V}(A,buf,buf2)
+	function HadamardJacobian(A::V,buf::C,buf2::C) where {C, V <: VCAT}
+		new{C, V}(A,buf,buf2)
 	end
 end
 
@@ -56,32 +56,29 @@ function Hadamard(L1::AbstractOperator,L2::AbstractOperator)
 
   V = VCAT(A,B)
 
-	buf  = zeros.(codomainType(V), size(V,1))
-	buf2 = zeros.(codomainType(V), size(V,1))
+  buf  = ArrayPartition(zeros.(codomainType(V), size(V,1)))
+  buf2 = ArrayPartition(zeros.(codomainType(V), size(V,1)))
 
 	Hadamard(V,buf,buf2)
 end
 
 # Mappings
-mul!(y, H::Hadamard{M,C,V}, x::ArrayPartition) where {M,C,V} = mul!(y,H,x.x)
-function mul!(y, H::Hadamard{M,C,V}, b) where {M,C,V}
+function mul!(y, H::Hadamard{C,V}, b::ArrayPartition) where {C,V}
 	mul!(H.buf,H.A,b)
-	y .= H.buf[1]
-  for i = 2:length(H.buf)
-    y .*= H.buf[i]
+	y .= H.buf.x[1]
+  for i = 2:length(H.buf.x)
+    y .*= H.buf.x[i]
 	end
 end
 
 # Jacobian
-Jacobian(A::H, x::D) where {M, D<:ArrayPartition, C, V, H <: Hadamard{M,C,V}} =
+Jacobian(A::H, x::D) where {D<:ArrayPartition, C, V, H <: Hadamard{C,V}} =
 HadamardJacobian(Jacobian(A.A,x),A.buf,A.buf2)
 
-mul!(y::ArrayPartition, A::AdjointOperator{HadamardJacobian{M,C,V}}, b) where {M,C,V} =
-mul!(y.x,A,b)
-function mul!(y, A::AdjointOperator{HadamardJacobian{M,C,V}}, b) where {M,C,V}
+function mul!(y::ArrayPartition, A::AdjointOperator{HadamardJacobian{C,V}}, b) where {C,V}
   J = A.A
-  for i = 1:length(J.buf)
-    J.buf2[i] .= (.*)(J.buf[1:i-1]...,J.buf[i+1:end]...,b)
+  for i = 1:length(J.buf.x)
+    J.buf2.x[i] .= (.*)(J.buf.x[1:i-1]...,J.buf.x[i+1:end]...,b)
 	end
 	mul!(y, J.A', J.buf2)
 end

--- a/src/calculus/Hadamard.jl
+++ b/src/calculus/Hadamard.jl
@@ -13,14 +13,14 @@ Compose opeators such that their output is multiplied elementwise:
 ```julia
 julia> n,m = 5,10
 
-julia> x = (randn(n),randn(m)); #inputs
+julia> x = ArrayPartition(randn(n),randn(m)); #inputs
 
 julia> A = randn(m,n); #A matrix
 
 julia> C = Hadamard( MatrixOp(A), Eye(m) )
 # i.e. `A(⋅).*I(⋅)`
 
-julia> Y = (A*x[1]).*x[2]
+julia> Y = (A*x.x[1]).*x.x[2]
 
 julia> C*x ≈ Y
 true

--- a/src/calculus/Hadamard.jl
+++ b/src/calculus/Hadamard.jl
@@ -54,7 +54,7 @@ function Hadamard(L1::AbstractOperator,L2::AbstractOperator)
 	A = HCAT(L1, Zeros( domainType(L2), size(L2,2), codomainType(L1), size(L1,1) ))
 	B = HCAT(Zeros( domainType(L1), size(L1,2), codomainType(L2), size(L2,1) ), L2 )
 
-    V = VCAT(A,B)
+  V = VCAT(A,B)
 
 	buf  = zeros.(codomainType(V), size(V,1))
 	buf2 = zeros.(codomainType(V), size(V,1))
@@ -63,27 +63,27 @@ function Hadamard(L1::AbstractOperator,L2::AbstractOperator)
 end
 
 # Mappings
+mul!(y, H::Hadamard{M,C,V}, x::ArrayPartition) where {M,C,V} = mul!(y,H,x.x)
 function mul!(y, H::Hadamard{M,C,V}, b) where {M,C,V}
 	mul!(H.buf,H.A,b)
-
 	y .= H.buf[1]
-    for i = 2:length(H.buf)
-		y .*= H.buf[i]
+  for i = 2:length(H.buf)
+    y .*= H.buf[i]
 	end
 end
 
 # Jacobian
-Jacobian(A::H, x::D) where {M, D<:Tuple, C, V, H <: Hadamard{M,C,V}} =
+Jacobian(A::H, x::D) where {M, D<:ArrayPartition, C, V, H <: Hadamard{M,C,V}} =
 HadamardJacobian(Jacobian(A.A,x),A.buf,A.buf2)
 
+mul!(y::ArrayPartition, A::AdjointOperator{HadamardJacobian{M,C,V}}, b) where {M,C,V} =
+mul!(y.x,A,b)
 function mul!(y, A::AdjointOperator{HadamardJacobian{M,C,V}}, b) where {M,C,V}
-    J = A.A
-    for i = 1:length(J.buf)
-		c = (J.buf[1:i-1]...,J.buf[i+1:end]...,b)
-		J.buf2[i] .= (.*)(c...)
+  J = A.A
+  for i = 1:length(J.buf)
+    J.buf2[i] .= (.*)(J.buf[1:i-1]...,J.buf[i+1:end]...,b)
 	end
 	mul!(y, J.A', J.buf2)
-
 end
 
 # Properties

--- a/src/calculus/Jacobian.jl
+++ b/src/calculus/Jacobian.jl
@@ -71,8 +71,8 @@ end
 #Jacobian of Reshape
 Jacobian(R::Reshape{N,L},x::AbstractArray) where {N,L} = Reshape(Jacobian(R.A,x),R.dim_out) 
 #Jacobian of Sum
-Jacobian(S::Sum{M,N,K,C,D},x::D) where {M,N,K,C,D} = 
-Sum(([Jacobian(a,x) for a in S.A]...,),S.bufC,S.bufD,M,N)
+Jacobian(S::Sum{K,C,D},x::D) where {K,C,D} = 
+Sum(([Jacobian(a,x) for a in S.A]...,),S.bufC,S.bufD)
 #Jacobian of Transpose
 Jacobian(T::Transpose{A}, x::AbstractArray) where {A <: AbstractOperator} = T 
 #Jacobian of BroadCast

--- a/src/calculus/Jacobian.jl
+++ b/src/calculus/Jacobian.jl
@@ -44,7 +44,7 @@ function Jacobian(H::DCAT{N,L,P1,P2},b) where {N,L,P1,P2}
 	DCAT(A,H.idxD,H.idxC)
 end
 #Jacobian of HCAT
-function Jacobian(H::HCAT{M,N,L,P,C},b::ArrayPartition) where {M,N,L,P,C,D} 
+function Jacobian(H::HCAT{N,L,P,C},b::ArrayPartition) where {N,L,P,C,D} 
   x = b.x
 	A = ()
     for (k, idx) in enumerate(H.idxs)
@@ -55,12 +55,12 @@ function Jacobian(H::HCAT{M,N,L,P,C},b::ArrayPartition) where {M,N,L,P,C,D}
             A = (A...,jacobian(H.A[k],xx)) 
         end
 	end
-	HCAT(A,H.idxs,H.buf,M)
+	HCAT(A,H.idxs,H.buf)
 end
 #Jacobian of VCAT
-function Jacobian(V::VCAT{M,N,L,P,C},x::D) where {M,N,L,P,C,D}
+function Jacobian(V::VCAT{N,L,P,C},x::AbstractArray) where {N,L,P,C,D}
     JJ = ([Jacobian(a,x) for a in V.A]...,)
-    VCAT{M,N,typeof(JJ),P,C}(JJ, V.idxs, V.buf)
+    VCAT(JJ, V.idxs, V.buf)
 end
 #Jacobian of Compose 
 function Jacobian(L::Compose, x::X) where {X<:AbstractArray} 

--- a/src/calculus/Jacobian.jl
+++ b/src/calculus/Jacobian.jl
@@ -19,17 +19,18 @@ J(σ)  ℝ^10 -> ℝ^10
 ```
 
 """
-struct Jacobian{T <: NonLinearOperator, X<:Union{AbstractArray,Tuple}} <: LinearOperator
+struct Jacobian{T <: NonLinearOperator, X<:AbstractArray} <: LinearOperator
 	A::T
 	x::X
 end
 
 #Jacobian of LinearOperator 
-Jacobian(L::T,x::X) where {T<:LinearOperator,X<:Union{AbstractArray,NTuple}} = L
+Jacobian(L::T,x::X) where {T<:LinearOperator,X<:AbstractArray} = L
 #Jacobian of Scale
 Jacobian(S::T2,x::AbstractArray) where {T,L,T2<:Scale{T,L}} = Scale(S.coeff,Jacobian(S.A,x)) 
 ##Jacobian of DCAT
-function Jacobian(H::DCAT{N,L,P1,P2},x) where {N,L,P1,P2} 
+function Jacobian(H::DCAT{N,L,P1,P2},b) where {N,L,P1,P2} 
+  x = b.x
 	A = ()
 	c = 0
     for (k, idx) in enumerate(H.idxD)
@@ -43,13 +44,14 @@ function Jacobian(H::DCAT{N,L,P1,P2},x) where {N,L,P1,P2}
 	DCAT(A,H.idxD,H.idxC)
 end
 #Jacobian of HCAT
-function Jacobian(H::HCAT{M,N,L,P,C},x::D) where {M,N,L,P,C,D} 
+function Jacobian(H::HCAT{M,N,L,P,C},b::ArrayPartition) where {M,N,L,P,C,D} 
+  x = b.x
 	A = ()
     for (k, idx) in enumerate(H.idxs)
 		if length(idx) == 1 
             A = (A...,jacobian(H.A[k],x[idx])) 
         else
-            xx = ([x[i] for i in idx]...,)
+            xx = ArrayPartition([x[i] for i in idx]...,)
             A = (A...,jacobian(H.A[k],xx)) 
         end
 	end

--- a/src/calculus/NonLinearCompose.jl
+++ b/src/calculus/NonLinearCompose.jl
@@ -14,12 +14,12 @@ Compose opeators in such fashion:
 ```julia
 julia> n1,m1,n2,m2 = 3,4,4,6 
 
-julia> x = (randn(n1,m1),randn(n2,m2)); #inputs
+julia> x = ArrayPartition(randn(n1,m1),randn(n2,m2)); #inputs
 
 julia> C = NonLinearCompose( Eye(n1,n2), Eye(m1,m2) )
 # i.e. `I(⋅)*I(⋅)`
 
-julia> Y = x[1]*x[2]
+julia> Y = x.x[1]*x.x[2]
 
 julia> C*x ≈ Y
 true

--- a/src/calculus/NonLinearCompose.jl
+++ b/src/calculus/NonLinearCompose.jl
@@ -26,11 +26,11 @@ true
 
 ```
 """
-struct NonLinearCompose{N,
+struct NonLinearCompose{
 			L1 <: HCAT{1},
 			L2 <: HCAT{1},
-			C <: Tuple{AbstractArray,AbstractArray},
-			D <: NTuple{N,Union{AbstractArray,Tuple}}
+			C <: AbstractArray,
+			D <: AbstractArray
 			} <: NonLinearOperator
 	A::L1
 	B::L2
@@ -44,24 +44,20 @@ struct NonLinearCompose{N,
             ) 
                 throw(DimensionMismatch("cannot compose operators"))
         end
-		N = length(bufx)
-		new{N,L1,L2,C,D}(A,B,buf,bufx)
+		new{L1,L2,C,D}(A,B,buf,bufx)
 	end
 end
 
-struct NonLinearComposeJac{N,
+struct NonLinearComposeJac{
 			   L1 <: HCAT{1},
 			   L2 <: HCAT{1},
-			   C <: Tuple{AbstractArray,AbstractArray},
-			   D <: NTuple{N,Union{AbstractArray,Tuple}}
+			   C <: AbstractArray,
+			   D <: AbstractArray 
 			   } <: LinearOperator
 	A::L1
 	B::L2
 	buf::C
 	bufx::D
-	function NonLinearComposeJac{N}(A::L1, B::L2, buf::C, bufx::D) where {N,L1,L2,C,D}
-		new{N,L1,L2,C,D}(A,B,buf,bufx)
-	end
 end
 
 # Constructors
@@ -70,49 +66,47 @@ function NonLinearCompose(L1::AbstractOperator,L2::AbstractOperator)
 	A = HCAT(L1, Zeros( domainType(L2), size(L2,2), codomainType(L1), size(L1,1) ))
 	B = HCAT(Zeros( domainType(L1), size(L1,2), codomainType(L2), size(L2,1) ), L2 )
 
-	buf  = zeros(codomainType(A),size(A,1)),zeros(codomainType(B),size(B,1))
-	bufx = zeros(codomainType(L1),size(L1,1)), zeros(codomainType(L2),size(L2,1))
+  buf  = ArrayPartition(zeros(codomainType(A),size(A,1)),   zeros(codomainType(B),size(B,1)))
+  bufx = ArrayPartition(zeros(codomainType(L1),size(L1,1)), zeros(codomainType(L2),size(L2,1)))
 
 	NonLinearCompose(A,B,buf,bufx)
 end
 
 # Jacobian
-function Jacobian(P::NonLinearCompose{N,L,C,D},x::DD) where  {M,N,L,C,
-							      D<: NTuple{N,Union{AbstractArray,Tuple}},
-							      DD<: NTuple{M,AbstractArray},
-							      }
-	NonLinearComposeJac{N}(Jacobian(P.A,x),Jacobian(P.B,x),P.buf,P.bufx)
+function Jacobian(P::NonLinearCompose{L1,L2,C,D}, x::AbstractArray) where  {L1,L2,C,D}
+	NonLinearComposeJac(Jacobian(P.A,x),Jacobian(P.B,x),P.buf,P.bufx)
 end
 
 # Mappings
-function mul!(y, P::NonLinearCompose{N,L1,L2,C,D}, b) where {N,L1,L2,C,D}
-	mul_skipZeros!(P.buf[1],P.A,b)
-	mul_skipZeros!(P.buf[2],P.B,b)
-	mul!(y,P.buf[1],P.buf[2])
+function mul!(y, P::NonLinearCompose{L1,L2,C,D}, b) where {L1,L2,C,D}
+	mul_skipZeros!(P.buf.x[1],P.A,b)
+	mul_skipZeros!(P.buf.x[2],P.B,b)
+	mul!(y,P.buf.x[1],P.buf.x[2])
 end
 
-function mul!(y, J::AdjointOperator{NonLinearComposeJac{N,L1,L2,C,D}}, b) where {N,L1,L2,C,D}
+function mul!(y, J::AdjointOperator{NonLinearComposeJac{L1,L2,C,D}}, b) where {L1,L2,C,D}
+  P = J.A
+	mul!(P.bufx.x[1],b,P.buf.x[2]')
+	mul_skipZeros!(y,P.A',P.bufx.x[1])
 
-    P = J.A
-	mul!(P.bufx[1],b,P.buf[2]')
-	mul_skipZeros!(y,P.A',P.bufx[1])
-
-	mul!(P.bufx[2],P.buf[1]',b)
-	mul_skipZeros!(y,P.B',P.bufx[2])
-
+	mul!(P.bufx.x[2],P.buf.x[1]',b)
+	mul_skipZeros!(y,P.B',P.bufx.x[2])
 end
 
 # special case outer product  
-function mul!(y, J::AdjointOperator{NonLinearComposeJac{N,L1,L2,C,D}}, b) where {N,L1,L2,C,D <: Tuple{AbstractVector,AbstractArray}}
+function mul!(y, 
+              J::AdjointOperator{NonLinearComposeJac{L1,L2,C,D}}, 
+              b) where {
+                        T, L1,L2,C, 
+                        A <: Tuple{AbstractVector,AbstractArray}, 
+                        D <: ArrayPartition{T,A} }
+  P = J.A
+  p = reshape(P.bufx.x[1], length(P.bufx.x[1]),1)
+  mul!(p,b,P.buf.x[2]')
+  mul_skipZeros!(y,P.A',P.bufx.x[1])
 
-    P = J.A
-    p = reshape(P.bufx[1], length(P.bufx[1]),1)
-    mul!(p,b,P.buf[2]')
-	mul_skipZeros!(y,P.A',P.bufx[1])
-
-	mul!(P.bufx[2],P.buf[1]',b)
-	mul_skipZeros!(y,P.B',P.bufx[2])
-
+	mul!(P.bufx.x[2],P.buf.x[1]',b)
+	mul_skipZeros!(y,P.B',P.bufx.x[2])
 end
 
 # Properties
@@ -138,7 +132,7 @@ domainType(L::NonLinearComposeJac)   = domainType.(Ref(L.A))
 codomainType(L::NonLinearComposeJac) = codomainType(L.A)
 
 # utils
-function permute(P::NonLinearCompose{N,L,C,D}, p::AbstractVector{Int}) where {N,L,C,D}
+function permute(P::NonLinearCompose{L,C,D}, p::AbstractVector{Int}) where {L,C,D}
 	NonLinearCompose(permute(P.A,p),permute(P.B,p),P.buf,P.bufx)
 end
 

--- a/src/calculus/NonLinearCompose.jl
+++ b/src/calculus/NonLinearCompose.jl
@@ -27,8 +27,8 @@ true
 ```
 """
 struct NonLinearCompose{
-			L1 <: HCAT{1},
-			L2 <: HCAT{1},
+			L1 <: HCAT,
+			L2 <: HCAT,
 			C <: AbstractArray,
 			D <: AbstractArray
 			} <: NonLinearOperator
@@ -49,8 +49,8 @@ struct NonLinearCompose{
 end
 
 struct NonLinearComposeJac{
-			   L1 <: HCAT{1},
-			   L2 <: HCAT{1},
+			   L1 <: HCAT,
+			   L2 <: HCAT,
 			   C <: AbstractArray,
 			   D <: AbstractArray 
 			   } <: LinearOperator

--- a/src/calculus/Reshape.jl
+++ b/src/calculus/Reshape.jl
@@ -70,3 +70,8 @@ is_full_column_rank(  R::Reshape) = is_full_column_rank(  R.A)
 
 fun_name(R::Reshape) = "¶"*fun_name(R.A)
 remove_displacement(R::Reshape) = Reshape(remove_displacement(R.A), R.dim_out)
+
+function permute(T::Reshape{N,L}, p::AbstractVector{Int}) where {N,L}
+    A = AbstractOperators.permute(T.A,p)
+    return Reshape(A,T.dim_out) 
+end

--- a/src/calculus/VCAT.jl
+++ b/src/calculus/VCAT.jl
@@ -19,7 +19,6 @@ julia> VCAT(DFT(4,4),Variation((4,4)))
 julia> V = [Eye(3); DiagOp(2*ones(3))]
 [I;╲]  ℝ^3 -> ℝ^3  ℝ^3
 
-
 julia> vcat(V,FiniteDiff((3,)))
 VCAT  ℝ^3 -> ℝ^3  ℝ^3  ℝ^2
 ```

--- a/src/calculus/VCAT.jl
+++ b/src/calculus/VCAT.jl
@@ -1,5 +1,5 @@
-
 export VCAT
+
 
 """
 `VCAT(A::AbstractOperator...)`
@@ -33,41 +33,35 @@ julia> V*ones(3)
 ```
 
 """
-struct VCAT{M, # number of domains  
-            N, # number of AbstractOperator 
+struct VCAT{N, # number of AbstractOperator 
             L <: NTuple{N,AbstractOperator},
-            P <: NTuple{N,Union{Int,Tuple}},
-            C <: Union{NTuple{M,AbstractArray}, AbstractArray},
-	       } <: AbstractOperator
+            P <: Tuple,
+            C <: AbstractArray,
+           } <: AbstractOperator
 	A::L     # tuple of AbstractOperators
 	idxs::P  # indices 
 	         # H = VCAT(Eye(n),VCAT(Eye(n),Eye(n))) has H.idxs = (1,2,3) 
-             # `AbstractOperators` are flatten
-	         # H = VCAT(Eye(n),Compose(MatrixOp(randn(n,n)),VCAT(Eye(n),Eye(n)))) 
-             # has H.idxs = (1,(2,3))
-             # `AbstractOperators` are stack
+           # `AbstractOperators` are flatten
+           # H = VCAT(Eye(n),Compose(MatrixOp(randn(n,n)),VCAT(Eye(n),Eye(n)))) 
+           # has H.idxs = (1,(2,3))
+           # `AbstractOperators` are stack
 	buf::C   # buffer memory
-end
-
-# Constructors
-
-function VCAT(A::L, idxs::P, buf::C, M::Int) where {N,  
-						    L <: NTuple{N,AbstractOperator},
-						    P <: NTuple{N,Union{Int,Tuple}},
-						    C
-						    } 
-	if any([size(A[1],2) != size(a,2) for a in A])
-		throw(DimensionMismatch("operators must have the same domain dimension!"))
-	end
-	if any([domainType(A[1]) != domainType(a) for a in A])
-		throw(error("operators must all share the same domainType!"))
-	end
-
-	VCAT{M,N,L,P,C}(A, idxs, buf)
+  function VCAT(A::L, idxs::P, buf::C) where {N,  
+                  L <: NTuple{N,AbstractOperator},
+                  P <: Tuple,
+                  C <: AbstractArray,
+                  }
+    if any([size(A[1],2) != size(a,2) for a in A])
+      throw(DimensionMismatch("operators must have the same domain dimension!"))
+    end
+    if any([domainType(A[1]) != domainType(a) for a in A])
+      throw(error("operators must all share the same domainType!"))
+    end
+    new{N,L,P,C}(A, idxs, buf)
+  end
 end
 
 function VCAT(A::Vararg{AbstractOperator})
-
 	if any((<:).(typeof.(A),VCAT)) #there are VCATs in A
 		AA = ()
 		for a in A
@@ -84,7 +78,7 @@ function VCAT(A::Vararg{AbstractOperator})
 		s = size(AA[1],2)
 		t = domainType(AA[1])
 		# generate buffer
-		buf = eltype(s) <: Int ? zeros(t,s) : zeros.(t,s)
+    buf = eltype(s) <: Int ? zeros(t,s) : ArrayPartition(zeros.(t,s))
 	end
 
 	return VCAT(AA, buf)
@@ -94,8 +88,6 @@ function VCAT(AA::NTuple{N,AbstractOperator}, buf::C) where {N,C}
 	if N == 1
 		return AA[1]
 	else
-		# get number of domains
-		M = C <: AbstractArray ? 1 : length(buf)
 		# build H.idxs
 		K = 0
 		idxs = []
@@ -104,167 +96,128 @@ function VCAT(AA::NTuple{N,AbstractOperator}, buf::C) where {N,C}
 				K += 1
 				push!(idxs,K)
 			else                   # stacked operator 
-				idxs = push!(idxs,(collect(K+1:K+ndoms(AA[i],1))...,) )
+				idxs = push!(idxs,(collect(K+1:K+ndoms(AA[i],2))...,) )
 				for ii = 1:ndoms(AA[i],1)
 					K += 1
 				end
 			end
 		end
-		return VCAT(AA, (idxs...,), buf, M)
+		return VCAT(AA, (idxs...,), buf)
 	end
 end
 
 VCAT(A::AbstractOperator) = A
 
 # Mappings
+@generated function mul!(y::C, A::AdjointOperator{VCAT{N,L,P,C}}, b::DD) where {N,L,P,C,DD <: ArrayPartition}
+  ex = :(H = A.A)
 
-mul!(y::C, A::AdjointOperator{VCAT{M,N,L,P,C}}, b::ArrayPartition) where {M,N,L,P,C} = 
-mul!(y,A,b.x)
-
-mul!(y::ArrayPartition, A::AdjointOperator{VCAT{M,N,L,P,C}}, b::ArrayPartition) where {M,N,L,P,C} = 
-mul!(y.x,A,b.x)
-
-@generated function mul!(y::C, A::AdjointOperator{VCAT{M,N,L,P,C}}, b::DD) where {M,N,L,P,C,DD}
-
-	ex = :(H = A.A)
-
-	if fieldtype(P,1) <: Int 
-		# flatten operator  
-		# build mul!(y, H.A[1]', b[H.idxs[1]])  
-		bb = :(b[H.idxs[1]])
+  if fieldtype(P,1) <: Int 
+    # flatten operator  
+    # build mul!(y, H.A[1]', b.x[H.idxs[1]])  
+    bb = :(b.x[H.idxs[1]])
 	else
-		# stacked operator 
-		# build mul!(y, H.A[1]',( b[H.idxs[1][1]], b[H.idxs[1][2]] ...  ))
-        bb = [ :(b[H.idxs[1][$ii]]) for ii in eachindex(fieldnames(fieldtype(P,1)))]
-        bb = :( tuple( $(bb...) ) )
+    # stacked operator 
+    # build mul!(y, H.A[1]',ArrayPartition( b.x[H.idxs[1][1]], b.x[H.idxs[1][2]] ...  ))
+    bb = [ :(b.x[H.idxs[1][$ii]]) for ii in eachindex(fieldnames(fieldtype(P,1)))]
+    bb = :( ArrayPartition($(bb...)) )
 	end
 	ex = :($ex; mul!(y,H.A[1]',$bb)) # write on y
 
-	for i = 2:N
-
-		if fieldtype(P,i) <: Int 
-		# flatten operator  
-		# build mul!(H.buf, H.A[i], b[H.idxs[i]])  
-			bb = :(b[H.idxs[$i]])
+  for i = 2:N
+    if fieldtype(P,i) <: Int 
+      # flatten operator  
+      # build mul!(H.buf, H.A[i]', b.x[H.idxs[i]])  
+      bb = :(b.x[H.idxs[$i]])
 		else
-		# stacked operator 
-		# build mul!(H.buf, H.A[i],( b[H.idxs[i][1]], b[H.idxs[i][2]] ...  ))
-        bb = [ :(b[H.idxs[$i][$ii]]) for ii in eachindex(fieldnames(fieldtype(P,i)))]
-        bb = :( tuple( $(bb...) ) )
+      # stacked operator 
+      # build mul!(H.buf, H.A[i]',( b.x[H.idxs[i][1]], b.x[H.idxs[i][2]] ...  ))
+      bb = [ :( b.x[H.idxs[$i][$ii]] ) for ii in eachindex(fieldnames(fieldtype(P,i)))]
+      bb = :( ArrayPartition( $(bb...) ) )
 		end
-
-		ex = :($ex; mul!(H.buf,H.A[$i]',$bb)) # write on H.buf
-		
-		# sum H.buf with y
-		if C <: AbstractArray
-			ex = :($ex; y .+= H.buf)
-		else
-			for ii = 1:M
-				ex = :($ex; y[$ii] .+= H.buf[$ii])
-			end
-		end
-
+    ex = :($ex; mul!(H.buf,H.A[$i]',$bb)) # write on H.buf
+    # sum H.buf with y
+    ex = :($ex; y .+= H.buf)
 	end
 	ex = :($ex; return y)
 	return ex
-
 end
 
-mul!(y::ArrayPartition, H::VCAT{M,N,L,P,C}, b::C) where {M,N,L,P,C} = mul!(y.x,H,b)
-mul!(y::ArrayPartition, H::VCAT{M,N,L,P,C}, b::ArrayPartition) where {M,N,L,P,C} = mul!(y.x,H,b.x)
-@generated function mul!(y::DD, H::VCAT{M,N,L,P,C}, b::C) where {M,N,L,P,C,DD}
-
-	ex = :()
-
-	for i = 1:N
-
-		if fieldtype(P,i) <: Int 
-		# flatten operator  
-		# build mul!(y[H.idxs[i]], H.A[i], b)  
-			yy = :(y[H.idxs[$i]])
-		else
-		# stacked operator 
-		# build mul!(( y[H.idxs[i][1]], y[H.idxs[i][2]] ...  ), H.A[i], b)
-        yy = [ :(y[H.idxs[$i][$ii]]) for ii in eachindex(fieldnames(fieldtype(P,i)))]
-        yy = :( tuple( $(yy...) ) )
-		end
-		
-		ex = :($ex; mul!($yy,H.A[$i],b))
-
+@generated function mul!(y::DD, H::VCAT{N,L,P,C}, b::C) where {N,L,P,C,DD <: ArrayPartition}
+  ex = :()
+  for i = 1:N
+    if fieldtype(P,i) <: Int 
+      # flatten operator  
+      # build mul!(y.x[H.idxs[i]], H.A[i], b)  
+      yy = :(y.x[H.idxs[$i]])
+    else
+      # stacked operator 
+      # build mul!(ArrayPartition( y[.xH.idxs[i][1]], y.x[H.idxs[i][2]] ...  ), H.A[i], b)
+      yy = [ :(y.x[H.idxs[$i][$ii]]) for ii in eachindex(fieldnames(fieldtype(P,i)))]
+      yy = :(ArrayPartition( $(yy...) ) )
+    end
+    ex = :($ex; mul!($yy,H.A[$i],b))
 	end
 	ex = :($ex; return y)
 	return ex
-
 end
 
-# same as mul but skips `Zeros`
-mul_skipZeros!(y::C, H::VCAT{M,N,L,P,C}, b::ArrayPartition) where {M,N,L,P,C,DD} = 
-mul_skipZeros!(y,H,b.x)
+## same as mul! but skips `Zeros`
+@generated function mul_skipZeros!(y::C, A::AdjointOperator{VCAT{N,L,P,C}}, b::DD) where {N,L,P,C,DD <: ArrayPartition}
+  ex = :(H = A.A)
 
-@generated function mul_skipZeros!(y::C, H::VCAT{M,N,L,P,C}, b::DD) where {M,N,L,P,C,DD}
-
-	ex = :()
-
-	if fieldtype(P,1) <: Int 
-		bb = :(b[H.idxs[1]])
+  if fieldtype(P,1) <: Int 
+    # flatten operator  
+    # build mul!(y, H.A[1]', b.x[H.idxs[1]])  
+    bb = :(b.x[H.idxs[1]])
 	else
-        bb = [:(b[H.idxs[1][$ii]]) for ii in eachindex(fieldnames(fieldtype(P,1)))]
-        bb = :( tuple( $(bb...) ) )
+    # stacked operator 
+    # build mul!(y, H.A[1]',ArrayPartition( b.x[H.idxs[1][1]], b.x[H.idxs[1][2]] ...  ))
+    bb = [ :(b.x[H.idxs[1][$ii]]) for ii in eachindex(fieldnames(fieldtype(P,1)))]
+    bb = :( ArrayPartition($(bb...)) )
 	end
-	ex = :($ex; mul!(y,H.A[1]',$bb))
+  ex = :($ex; mul!(y,H.A[1]',$bb)) # write on y
 
-	for i = 2:N
-		if !(fieldtype(L,i) <: Zeros)
-
-			if fieldtype(P,i) <: Int 
-				bb = :(b[H.idxs[$i]])
-			else
-                bb = [ :(b[H.idxs[$i][$ii]]) for ii in eachindex(fieldnames(fieldtype(P,i))) ]
-                bb = :( tuple( $(bb...) ) )
-			end
-
-			ex = :($ex; mul!(H.buf,H.A[$i]',$bb))
-			
-			if C <: AbstractArray
-				ex = :($ex; y .+= H.buf)
-			else
-				for ii = 1:M
-					ex = :($ex; y[$ii] .+= H.buf[$ii])
-				end
-			end
-		end
-
+  for i = 2:N
+    if !(fieldtype(L,i) <: Zeros)
+      if fieldtype(P,i) <: Int 
+        # flatten operator  
+        # build mul!(H.buf, H.A[i]', b.x[H.idxs[i]])  
+        bb = :(b.x[H.idxs[$i]])
+      else
+        # stacked operator 
+        # build mul!(H.buf, H.A[i]',( b.x[H.idxs[i][1]], b.x[H.idxs[i][2]] ...  ))
+        bb = [ :( b.x[H.idxs[$i][$ii]] ) for ii in eachindex(fieldnames(fieldtype(P,i)))]
+        bb = :( ArrayPartition( $(bb...) ) )
+      end
+      ex = :($ex; mul!(H.buf,H.A[$i]',$bb)) # write on H.buf
+      # sum H.buf with y
+      ex = :($ex; y .+= H.buf)
+    end
 	end
 	ex = :($ex; return y)
 	return ex
-
 end
 
-# same as mul but skips `Zeros`
-mul_skipZeros!(y::ArrayPartition, H::VCAT{M,N,L,P,C}, b::C) where {M,N,L,P,C} = 
-mul_skipZeros!(y.x,H,b)
-
-@generated function mul_skipZeros!(y::DD, H::VCAT{M,N,L,P,C}, b::C) where {M,N,L,P,C,DD}
-
-	ex = :()
-
-	for i = 1:N
-
-		if !(fieldtype(L,i) <: Zeros)
-			if fieldtype(P,i) <: Int 
-				yy = :(y[H.idxs[$i]])
-			else
-                yy = [:(y[H.idxs[$i][$ii]]) for ii in eachindex(fieldnames(fieldtype(P,i)))]
-                yy = :( tuple( $(yy...)) )
-			end
-			
-			ex = :($ex; mul!($yy,H.A[$i],b))
-		end
-
+@generated function mul_skipZeros!(y::DD, H::VCAT{N,L,P,C}, b::C) where {N,L,P,C,DD <: ArrayPartition}
+  ex = :()
+  for i = 1:N
+    if !(fieldtype(L,i) <: Zeros)
+      if fieldtype(P,i) <: Int 
+        # flatten operator  
+        # build mul!(y.x[H.idxs[i]], H.A[i], b)  
+        yy = :(y.x[H.idxs[$i]])
+      else
+        # stacked operator 
+        # build mul!(ArrayPartition( y[.xH.idxs[i][1]], y.x[H.idxs[i][2]] ...  ), H.A[i], b)
+        yy = [ :(y.x[H.idxs[$i][$ii]]) for ii in eachindex(fieldnames(fieldtype(P,i)))]
+        yy = :(ArrayPartition( $(yy...) ) )
+      end
+      ex = :($ex; mul!($yy,H.A[$i],b))
+    end
 	end
 	ex = :($ex; return y)
 	return ex
-
 end
 
 # Properties
@@ -297,7 +250,7 @@ is_full_column_rank(L::VCAT) = any(is_full_column_rank.(L.A))
 diag_AcA(L::VCAT) = (+).(diag_AcA.(L.A)...,)
 
 # utils
-function permute(H::VCAT{M,N,L,P,C}, p::AbstractVector{Int}) where {M,N,L,P,C}
+function permute(H::VCAT{N,L,P,C}, p::AbstractVector{Int}) where {N,L,P,C}
 
 
 	unfolded = vcat([[idx... ] for idx in H.idxs]...) 
@@ -313,4 +266,4 @@ function permute(H::VCAT{M,N,L,P,C}, p::AbstractVector{Int}) where {M,N,L,P,C}
 	VCAT{M,N,L,P,C}(H.A,new_part,H.buf)
 end
 
-remove_displacement(V::VCAT{M}) where {M} = VCAT(remove_displacement.(V.A), V.idxs, V.buf, M)
+remove_displacement(V::VCAT) = VCAT(remove_displacement.(V.A), V.idxs, V.buf)

--- a/src/calculus/VCAT.jl
+++ b/src/calculus/VCAT.jl
@@ -118,6 +118,12 @@ VCAT(A::AbstractOperator) = A
 
 # Mappings
 
+mul!(y::C, A::AdjointOperator{VCAT{M,N,L,P,C}}, b::ArrayPartition) where {M,N,L,P,C} = 
+mul!(y,A,b.x)
+
+mul!(y::ArrayPartition, A::AdjointOperator{VCAT{M,N,L,P,C}}, b::ArrayPartition) where {M,N,L,P,C} = 
+mul!(y.x,A,b.x)
+
 @generated function mul!(y::C, A::AdjointOperator{VCAT{M,N,L,P,C}}, b::DD) where {M,N,L,P,C,DD}
 
 	ex = :(H = A.A)
@@ -164,6 +170,8 @@ VCAT(A::AbstractOperator) = A
 
 end
 
+mul!(y::ArrayPartition, H::VCAT{M,N,L,P,C}, b::C) where {M,N,L,P,C} = mul!(y.x,H,b)
+mul!(y::ArrayPartition, H::VCAT{M,N,L,P,C}, b::ArrayPartition) where {M,N,L,P,C} = mul!(y.x,H,b.x)
 @generated function mul!(y::DD, H::VCAT{M,N,L,P,C}, b::C) where {M,N,L,P,C,DD}
 
 	ex = :()
@@ -190,6 +198,9 @@ end
 end
 
 # same as mul but skips `Zeros`
+mul_skipZeros!(y::C, H::VCAT{M,N,L,P,C}, b::ArrayPartition) where {M,N,L,P,C,DD} = 
+mul_skipZeros!(y,H,b.x)
+
 @generated function mul_skipZeros!(y::C, H::VCAT{M,N,L,P,C}, b::DD) where {M,N,L,P,C,DD}
 
 	ex = :()
@@ -230,6 +241,9 @@ end
 end
 
 # same as mul but skips `Zeros`
+mul_skipZeros!(y::ArrayPartition, H::VCAT{M,N,L,P,C}, b::C) where {M,N,L,P,C} = 
+mul_skipZeros!(y.x,H,b)
+
 @generated function mul_skipZeros!(y::DD, H::VCAT{M,N,L,P,C}, b::C) where {M,N,L,P,C,DD}
 
 	ex = :()

--- a/src/linearoperators/LBFGS.jl
+++ b/src/linearoperators/LBFGS.jl
@@ -37,10 +37,10 @@ end
 #default constructor
 
 function LBFGS(x::T, M::I) where {T <: AbstractArray, I <: Integer}
-	s_M = [0 .*similar(x) for i = 1:M]
-	y_M = [0 .*similar(x) for i = 1:M]
-	s = 0 .*similar(x)
-	y = 0 .*similar(x)
+	s_M = [zero(x) for i = 1:M]
+	y_M = [zero(x) for i = 1:M]
+	s = zero(x)
+	y = zero(x)
   R = real(eltype(x))
 	ys_M = zeros(R, M)
 	alphas = zeros(R, M)

--- a/src/linearoperators/LBFGS.jl
+++ b/src/linearoperators/LBFGS.jl
@@ -22,7 +22,7 @@ julia> d = L*grad; # compute new direction
 Use  `reset!(L)` to cancel the memory of the operator.
 
 """
-mutable struct LBFGS{R, T <: BlockArray, M, I <: Integer} <: LinearOperator
+mutable struct LBFGS{R, T <: AbstractArray, M, I <: Integer} <: LinearOperator
 	currmem::I
 	curridx::I
 	s::T
@@ -36,27 +36,15 @@ end
 
 #default constructor
 
-function LBFGS(domainType, dim_in, M::I) where {I <: Integer}
-	s_M = [blockzeros(domainType, dim_in) for i = 1:M]
-	y_M = [blockzeros(domainType, dim_in) for i = 1:M]
-	s = blockzeros(domainType, dim_in)
-	y = blockzeros(domainType, dim_in)
-	T = typeof(s)
-	R = typeof(domainType) <: Tuple  ? real(domainType[1]) : real(domainType)
+function LBFGS(x::T, M::I) where {T <: AbstractArray, I <: Integer}
+	s_M = [0 .*similar(x) for i = 1:M]
+	y_M = [0 .*similar(x) for i = 1:M]
+	s = 0 .*similar(x)
+	y = 0 .*similar(x)
+  R = real(eltype(x))
 	ys_M = zeros(R, M)
 	alphas = zeros(R, M)
 	LBFGS{R, T, M, I}(0, 0, s, y, s_M, y_M, ys_M, alphas, one(R))
-end
-
-function LBFGS(dim_in, M::I) where {I <: Integer}
-	domainType = eltype(dim_in) <: Integer ? Float64 : ([Float64 for i in eachindex(dim_in)]...,)
-	LBFGS(domainType, dim_in, M)
-end
-
-function LBFGS(x::T, M::I) where {T <: BlockArray, I <: Integer}
-	domainType = blockeltype(x)
-	dim_in = blocksize(x)
-	LBFGS(domainType, dim_in, M)
 end
 
 """
@@ -65,23 +53,21 @@ end
 See the documentation for `LBFGS`.
 """
 function update!(L::LBFGS{R, T, M, I}, x::T, x_prev::T, gradx::T, gradx_prev::T) where {R, T, M, I}
-	#L.s .= x .- x_prev
-    blockaxpy!(L.s, x, -1, x_prev)
-	#L.y .= gradx .- gradx_prev
-    blockaxpy!(L.y, gradx, -1, gradx_prev)
-	ys = real(blockvecdot(L.s, L.y))
+	L.s .= x .- x_prev
+	L.y .= gradx .- gradx_prev
+	ys = real(dot(L.s, L.y))
 	if ys > 0
 		L.curridx += 1
 		if L.curridx > M L.curridx = 1 end
 		L.currmem += 1
 		if L.currmem > M L.currmem = M end
 		L.ys_M[L.curridx] = ys
-		blockcopy!(L.s_M[L.curridx], L.s)
-		blockcopy!(L.y_M[L.curridx], L.y)
-		yty = real(blockvecdot(L.y, L.y))
+		L.s_M[L.curridx] .= L.s
+		L.y_M[L.curridx] .= L.y
+		yty = real(dot(L.y, L.y))
 		L.H = ys/yty
 	end
-	return L
+  return L
 end
 
 """
@@ -101,42 +87,42 @@ mul!(x::T, L::AdjointOperator{LBFGS{R, T, M, I}}, y::T) where {R, T, M, I} = mul
 # Two-loop recursion
 
 function mul!(d::T, L::LBFGS{R, T, M, I}, gradx::T) where {R, T, M, I}
-	#d .= gradx
-    blockcopy!(d,gradx)
+	d .= gradx
 	idx = loop1!(d,L)
-	#d .= (*).(L.H, d)
-    blockscale!(d, L.H, d)
-	d = loop2!(d,idx,L)
+	d .*= L.H
+	loop2!(d,idx,L)
+  return d
 end
 
 function loop1!(d::T, L::LBFGS{R, T, M, I}) where {R, T, M, I}
 	idx = L.curridx
 	for i = 1:L.currmem
-		L.alphas[idx] = real(blockvecdot(L.s_M[idx], d))/L.ys_M[idx]
-		#d .-= L.alphas[idx] .* L.y_M[idx]
-        blockcumscale!(d, -L.alphas[idx], L.y_M[idx])
+		L.alphas[idx] = real(dot(L.s_M[idx], d))/L.ys_M[idx]
+		d .-= L.alphas[idx] .* L.y_M[idx]
 		idx -= 1
 		if idx == 0 idx = M end
 	end
 	return idx
 end
 
-function loop2!(d::T, idx::Int, L::LBFGS{R, T, M, I}) where {R, T, M, I}
+function loop2!(d::T, idx, L::LBFGS{R, T, M, I}) where {R, T, M, I}
 	for i = 1:L.currmem
 		idx += 1
 		if idx > M idx = 1 end
-		beta = real(blockvecdot(L.y_M[idx], d))/L.ys_M[idx]
-		#d .+= (L.alphas[idx] - beta) .* L.s_M[idx]
-        blockcumscale!(d, L.alphas[idx] - beta, L.s_M[idx])
+		beta = real(dot(L.y_M[idx], d))/L.ys_M[idx]
+		d .+= (L.alphas[idx] - beta) .* L.s_M[idx]
 	end
 	return d
 end
 
 # Properties
 
-domainType(L::LBFGS{R, T, M, I}) where {R, T, M, I} = blockeltype(L.y_M[1])
-codomainType(L::LBFGS{R, T, M, I}) where {R, T, M, I} = blockeltype(L.y_M[1])
+domainType(L::LBFGS)   =   eltype(L.y_M[1])
+domainType(L::LBFGS{R,T}) where { R, T <: ArrayPartition } = eltype.(L.y_M[1].x)
+codomainType(L::LBFGS) = eltype(L.y_M[1])
+codomainType(L::LBFGS{R,T}) where { R, T <: ArrayPartition } = eltype.(L.y_M[1].x)
 
-size(A::LBFGS) = (blocksize(A.s), blocksize(A.s))
+size(A::LBFGS{R,T}) where { R, T <: ArrayPartition } = (size.(A.s.x), size.(A.s.x))
+size(A::LBFGS) = (size(A.s), size(A.s))
 
 fun_name(A::LBFGS) = "LBFGS"

--- a/src/properties.jl
+++ b/src/properties.jl
@@ -287,12 +287,18 @@ julia> displacement(A)
 ```
 """
 function displacement(S::AbstractOperator) 
-    d = S*blockzeros(domainType(S),size(S,2))
-    if all(y -> y == d[1], d ) 
-        return d[1]
-    else
-        return d
-    end
+  D = domainType(S)
+  if typeof(D) <: Tuple
+    x = ArrayPartition(zeros.(D, size(S, 2))...)
+  else
+	  x = zeros(D, size(S, 2))
+  end
+  d = S*x
+  if all(y -> y == d[1], d ) 
+    return d[1]
+  else
+    return d
+  end
 end
 
 """

--- a/src/syntax.jl
+++ b/src/syntax.jl
@@ -40,7 +40,7 @@ function getindex(A::AbstractOperator,idx...)
 end
 
 #get index of HCAT returns HCAT (or Operator)
-function getindex(H::A, idx::Union{AbstractArray,Int}) where {M,N,L,P,C,A<:HCAT{M,N,L,P,C}}
+function getindex(H::HCAT, idx::Union{AbstractArray,Int})
 
 	unfolded = vcat([[i... ] for i in H.idxs]...)
 	if length(idx) == length(unfolded)
@@ -64,7 +64,7 @@ end
 
 
 #get index of HCAT returns HCAT (or Operator)
-function getindex(H::A, idx::Union{AbstractArray,Int}) where {M,N,L,P,C,A<:VCAT{M,N,L,P,C}}
+function getindex(H::VCAT, idx::Union{AbstractArray,Int})
 
 	unfolded = vcat([[i... ] for i in H.idxs]...)
 	if length(idx) == length(unfolded)

--- a/src/syntax.jl
+++ b/src/syntax.jl
@@ -11,11 +11,18 @@ adjoint(L::T) where {T <: AbstractOperator} = AdjointOperator(L)
 (-)(L1::AbstractOperator, L2::AbstractOperator) = Sum(L1, -L2 )
 
 ###### * ######
-function (*)(L::AbstractOperator, b::T) where {T <: BlockArray}
-	y = blockzeros(codomainType(L), size(L, 1))
+function (*)(L::AbstractOperator, b::AbstractArray)
+  C = codomainType(L)
+  if typeof(C) <: Tuple
+    y = ArrayPartition(zeros.(codomainType(L), size(L, 1))...)
+  else
+	  y = zeros(codomainType(L), size(L, 1))
+  end
 	mul!(y, L, b)
 	return y
 end
+
+#(*)(L::AbstractOperator, b::Tuple) = (*)(L, ArrayPartition(b...))
 
 *(coeff::T, L::AbstractOperator) where {T<:Number} = Scale(coeff,L)
 *(L1::AbstractOperator, L2::AbstractOperator) = Compose(L1,L2)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,18 +23,17 @@ end
 @testset "Linear Calculus rules" begin
   include("test_linear_operators_calculus.jl")
 end
-#
-#@testset "Nonlinear Calculus rules" begin
-#  include("test_nonlinear_operators_calculus.jl")
-#end
+
+@testset "Nonlinear Calculus rules" begin
+  include("test_nonlinear_operators_calculus.jl")
+end
 
 @testset "L-BFGS" begin
   include("test_lbfgs.jl")
 end
 
-#@testset "Syntax shorthands" begin
-#  include("test_syntax.jl")
-#end
-
+@testset "Syntax shorthands" begin
+  include("test_syntax.jl")
 end
 
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using AbstractOperators
-using LinearAlgebra, FFTW, DSP, SparseArrays
+using LinearAlgebra, FFTW, DSP, SparseArrays, RecursiveArrayTools
 using Printf
 using Random
 using Test
@@ -12,33 +12,29 @@ verb = true
 
 @testset "AbstractOperators" begin
 
-@testset "Block Arrays" begin
-  include("test_block.jl")
-end
-
-@testset "Linear operators" begin
-  include("test_linear_operators.jl")
-end
-
-@testset "Non-Linear operators" begin
-  include("test_nonlinear_operators.jl")
-end
+#@testset "Linear operators" begin
+#  include("test_linear_operators.jl")
+#end
+#
+#@testset "Non-Linear operators" begin
+#  include("test_nonlinear_operators.jl")
+#end
 
 @testset "Linear Calculus rules" begin
   include("test_linear_operators_calculus.jl")
 end
+#
+#@testset "Nonlinear Calculus rules" begin
+#  include("test_nonlinear_operators_calculus.jl")
+#end
 
-@testset "Nonlinear Calculus rules" begin
-  include("test_nonlinear_operators_calculus.jl")
-end
+#@testset "L-BFGS" begin
+#  include("test_lbfgs.jl")
+#end
 
-@testset "L-BFGS" begin
-  include("test_lbfgs.jl")
-end
-
-@testset "Syntax shorthands" begin
-  include("test_syntax.jl")
-end
+#@testset "Syntax shorthands" begin
+#  include("test_syntax.jl")
+#end
 
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,13 +12,13 @@ verb = true
 
 @testset "AbstractOperators" begin
 
-#@testset "Linear operators" begin
-#  include("test_linear_operators.jl")
-#end
-#
-#@testset "Non-Linear operators" begin
-#  include("test_nonlinear_operators.jl")
-#end
+@testset "Linear operators" begin
+  include("test_linear_operators.jl")
+end
+
+@testset "Non-Linear operators" begin
+  include("test_nonlinear_operators.jl")
+end
 
 @testset "Linear Calculus rules" begin
   include("test_linear_operators_calculus.jl")
@@ -28,9 +28,9 @@ end
 #  include("test_nonlinear_operators_calculus.jl")
 #end
 
-#@testset "L-BFGS" begin
-#  include("test_lbfgs.jl")
-#end
+@testset "L-BFGS" begin
+  include("test_lbfgs.jl")
+end
 
 #@testset "Syntax shorthands" begin
 #  include("test_syntax.jl")

--- a/test/test_linear_operators_calculus.jl
+++ b/test/test_linear_operators_calculus.jl
@@ -1,101 +1,101 @@
-@printf("\nTesting linear operators calculus rules\n")
-
-##########################
-##### test Compose #######
-##########################
-m1, m2, m3 = 4, 7, 3
-A1 = randn(m2, m1)
-A2 = randn(m3, m2)
-opA1 = MatrixOp(A1)
-opA2 = MatrixOp(A2)
-
-opC = Compose(opA2,opA1)
-x = randn(m1)
-y1 = test_op(opC, x, randn(m3), verb)
-y2 = A2*A1*x
-@test all(norm.(y1 .- y2) .<= 1e-12)
-
-# test Compose longer
-m1, m2, m3, m4 = 4, 7, 3, 2
-A1 = randn(m2, m1)
-A2 = randn(m3, m2)
-A3 = randn(m4, m3)
-opA1 = MatrixOp(A1)
-opA2 = MatrixOp(A2)
-opA3 = MatrixOp(A3)
-
-opC1 = Compose(opA3,Compose(opA2,opA1))
-opC2 = Compose(Compose(opA3,opA2),opA1)
-x = randn(m1)
-y1 = test_op(opC1, x, randn(m4), verb)
-y2 = test_op(opC2, x, randn(m4), verb)
-y3 = A3*A2*A1*x
-@test all(norm.(y1 .- y2) .<= 1e-12)
-@test all(norm.(y3 .- y2) .<= 1e-12)
-
-#test Compose special cases
-@test typeof(opA1*Eye(m1)) == typeof(opA1) 
-@test typeof(Eye(m2)*opA1) == typeof(opA1) 
-@test typeof(Eye(m2)*Eye(m2)) == typeof(Eye(m2)) 
-
-opS1 = Compose(opA2,opA1)
-opS1c = Scale(pi,opS1)
-@test typeof(opS1c.A[end]) <: Scale
-
-#properties
-@test is_sliced(opC)            == false
-@test is_linear(opC1)           == true
-@test is_null(opC1)             == false
-@test is_eye(opC1)              == false
-@test is_diagonal(opC1)         == false
-@test is_AcA_diagonal(opC1)     == false
-@test is_AAc_diagonal(opC1)     == false
-@test is_orthogonal(opC1)       == false
-@test is_invertible(opC1)       == false
-@test is_full_row_rank(opC1)    == false
-@test is_full_column_rank(opC1) == false
-
-# properties special case
-opC = DCT((5,))*GetIndex((10,), 1:5)
-@test is_sliced(opC)           == true
-@test is_AAc_diagonal(opC)     == true
-@test diag_AAc(opC)            == 1.0
-
-d = randn(5)
-opC = DiagOp(d)*GetIndex((10,), 1:5)
-@test is_sliced(opC)           == true
-@test is_diagonal(opC)         == true
-@test diag(opC)                == d
-
-# displacement test
-m1, m2, m3, m4, m5 = 4, 7, 3, 2, 11
-A1 = randn(m2, m1)
-A2 = randn(m3, m2)
-A3 = randn(m4, m3)
-A4 = randn(m5, m4)
-d1 = randn(m2)
-d2 = pi
-d3 = 0.0
-d4 = randn(m5)
-opA1 = AffineAdd(MatrixOp(A1),d1)  
-opA2 = AffineAdd(MatrixOp(A2),d2)
-opA3 = MatrixOp(A3)
-opA4 = AffineAdd(MatrixOp(A4),d4,false) 
-
-opC  = Compose(Compose(Compose(opA4,opA3),opA2),opA1)
-
-x = randn(m1)
-
-@test norm( opC*x - (A4*(A3*( A2*( A1*x+d1 ) .+ d2 ) .+ d3)-d4) )  < 1e-9
-@test norm( displacement(opC) - ( A4*(A3*(A2*d1 .+d2 ) .+ d3)-d4) ) < 1e-9
-
-opA4 = MatrixOp(A4)
-opC  = AffineAdd(Compose(Compose(Compose(opA4,opA3),opA2),opA1),d4)
-@test norm( opC*x - (A4*(A3*( A2*( A1*x+d1 ) .+ d2 ) .+ d3)+d4) )  < 1e-9
-@test norm( displacement(opC) - ( A4*(A3*(A2*d1 .+ d2) .+ d3)+d4) ) < 1e-9
-
-@test norm( remove_displacement(opC)*x - (A4*(A3*( A2*( A1*x ) ) ) ) )  < 1e-9
-
+#@printf("\nTesting linear operators calculus rules\n")
+#
+###########################
+###### test Compose #######
+###########################
+#m1, m2, m3 = 4, 7, 3
+#A1 = randn(m2, m1)
+#A2 = randn(m3, m2)
+#opA1 = MatrixOp(A1)
+#opA2 = MatrixOp(A2)
+#
+#opC = Compose(opA2,opA1)
+#x = randn(m1)
+#y1 = test_op(opC, x, randn(m3), verb)
+#y2 = A2*A1*x
+#@test all(norm.(y1 .- y2) .<= 1e-12)
+#
+## test Compose longer
+#m1, m2, m3, m4 = 4, 7, 3, 2
+#A1 = randn(m2, m1)
+#A2 = randn(m3, m2)
+#A3 = randn(m4, m3)
+#opA1 = MatrixOp(A1)
+#opA2 = MatrixOp(A2)
+#opA3 = MatrixOp(A3)
+#
+#opC1 = Compose(opA3,Compose(opA2,opA1))
+#opC2 = Compose(Compose(opA3,opA2),opA1)
+#x = randn(m1)
+#y1 = test_op(opC1, x, randn(m4), verb)
+#y2 = test_op(opC2, x, randn(m4), verb)
+#y3 = A3*A2*A1*x
+#@test all(norm.(y1 .- y2) .<= 1e-12)
+#@test all(norm.(y3 .- y2) .<= 1e-12)
+#
+##test Compose special cases
+#@test typeof(opA1*Eye(m1)) == typeof(opA1) 
+#@test typeof(Eye(m2)*opA1) == typeof(opA1) 
+#@test typeof(Eye(m2)*Eye(m2)) == typeof(Eye(m2)) 
+#
+#opS1 = Compose(opA2,opA1)
+#opS1c = Scale(pi,opS1)
+#@test typeof(opS1c.A[end]) <: Scale
+#
+##properties
+#@test is_sliced(opC)            == false
+#@test is_linear(opC1)           == true
+#@test is_null(opC1)             == false
+#@test is_eye(opC1)              == false
+#@test is_diagonal(opC1)         == false
+#@test is_AcA_diagonal(opC1)     == false
+#@test is_AAc_diagonal(opC1)     == false
+#@test is_orthogonal(opC1)       == false
+#@test is_invertible(opC1)       == false
+#@test is_full_row_rank(opC1)    == false
+#@test is_full_column_rank(opC1) == false
+#
+## properties special case
+#opC = DCT((5,))*GetIndex((10,), 1:5)
+#@test is_sliced(opC)           == true
+#@test is_AAc_diagonal(opC)     == true
+#@test diag_AAc(opC)            == 1.0
+#
+#d = randn(5)
+#opC = DiagOp(d)*GetIndex((10,), 1:5)
+#@test is_sliced(opC)           == true
+#@test is_diagonal(opC)         == true
+#@test diag(opC)                == d
+#
+## displacement test
+#m1, m2, m3, m4, m5 = 4, 7, 3, 2, 11
+#A1 = randn(m2, m1)
+#A2 = randn(m3, m2)
+#A3 = randn(m4, m3)
+#A4 = randn(m5, m4)
+#d1 = randn(m2)
+#d2 = pi
+#d3 = 0.0
+#d4 = randn(m5)
+#opA1 = AffineAdd(MatrixOp(A1),d1)  
+#opA2 = AffineAdd(MatrixOp(A2),d2)
+#opA3 = MatrixOp(A3)
+#opA4 = AffineAdd(MatrixOp(A4),d4,false) 
+#
+#opC  = Compose(Compose(Compose(opA4,opA3),opA2),opA1)
+#
+#x = randn(m1)
+#
+#@test norm( opC*x - (A4*(A3*( A2*( A1*x+d1 ) .+ d2 ) .+ d3)-d4) )  < 1e-9
+#@test norm( displacement(opC) - ( A4*(A3*(A2*d1 .+d2 ) .+ d3)-d4) ) < 1e-9
+#
+#opA4 = MatrixOp(A4)
+#opC  = AffineAdd(Compose(Compose(Compose(opA4,opA3),opA2),opA1),d4)
+#@test norm( opC*x - (A4*(A3*( A2*( A1*x+d1 ) .+ d2 ) .+ d3)+d4) )  < 1e-9
+#@test norm( displacement(opC) - ( A4*(A3*(A2*d1 .+ d2) .+ d3)+d4) ) < 1e-9
+#
+#@test norm( remove_displacement(opC)*x - (A4*(A3*( A2*( A1*x ) ) ) ) )  < 1e-9
+#
 #########################
 #### test DCAT    #######
 #########################
@@ -108,9 +108,9 @@ opA2 = MatrixOp(A2)
 opD = DCAT(opA1, opA2)
 x1 = randn(n1)
 x2 = randn(n2)
-y1 = test_op(opD, (x1, x2), (randn(m1),randn(m2)), verb)
-y2 = (A1*x1, A2*x2)
-@test all(norm.(y1 .- y2) .<= 1e-12)
+y1 = test_op(opD, ArrayPartition(x1, x2), ArrayPartition(randn(m1),randn(m2)), verb)
+y2 = ArrayPartition(A1*x1, A2*x2)
+@test norm(y1 .- y2) .<= 1e-12
 
 # test DCAT longer
 
@@ -125,9 +125,9 @@ opD = DCAT(opA1, opA2, opA3)
 x1 = randn(n1)
 x2 = randn(n2)
 x3 = randn(n3)
-y1 = test_op(opD, (x1, x2, x3), (randn(m1),randn(m2),randn(m3)), verb)
-y2 = (A1*x1, A2*x2, A3*x3)
-@test all(norm.(y1 .- y2) .<= 1e-12)
+y1 = test_op(opD, ArrayPartition(x1, x2, x3), ArrayPartition(randn(m1),randn(m2),randn(m3)), verb)
+y2 = ArrayPartition(A1*x1, A2*x2, A3*x3)
+@test norm(y1 .- y2) .<= 1e-12
 
 #properties
 @test is_linear(opD)           == true
@@ -147,8 +147,8 @@ n1, n2 = 4, 7
 x1 = randn(n1)
 x2 = randn(n2)
 
-opD = Eye((x1,x2))
-y1 = test_op(opD, (x1, x2), (randn(n1),randn(n2)), verb)
+opD = Eye(ArrayPartition(x1,x2))
+y1 = test_op(opD, ArrayPartition(x1, x2), ArrayPartition(randn(n1),randn(n2)), verb)
 
 #properties
 @test is_linear(opD)           == true
@@ -182,914 +182,914 @@ opD = DCAT(opA1, opA2, opA3)
 x1 = randn(n1)
 x2 = randn(n2)
 x3 = randn(n3)
-y1 = opD*(x1,x2,x3)
-y2 = (A1*x1+d1, A2*x2+d2, A3*x3+d3)
-@test all(norm.(y1 .- y2) .<= 1e-12)
-@test all(norm.(displacement(opD) .- (d1,d2,d3)) .<= 1e-12)
-y1 = remove_displacement(opD)*(x1,x2,x3)
-y2 = (A1*x1, A2*x2, A3*x3)
-@test all(norm.(y1 .- y2) .<= 1e-12)
-
-#######################
-## test HCAT    #######
-#######################
-
-m, n1, n2 = 4, 7, 5
-A1 = randn(m, n1)
-A2 = randn(m, n2)
-opA1 = MatrixOp(A1)
-opA2 = MatrixOp(A2)
-opH = HCAT(opA1, opA2)
-x1 = randn(n1)
-x2 = randn(n2)
-y1 = test_op(opH, (x1, x2), randn(m), verb)
-y2 = A1*x1 + A2*x2
-@test norm(y1-y2) <= 1e-12
-
-#permuatation 
-p = [2;1]
-opHp = opH[p]
-y1 = test_op(opHp, (x2, x1), randn(m), verb)
-@test norm(y1-y2) <= 1e-12
-
-# test HCAT longer
-
-m, n1, n2, n3 = 4, 7, 5, 6
-A1 = randn(m, n1)
-A2 = randn(m, n2)
-A3 = randn(m, n3)
-opA1 = MatrixOp(A1)
-opA2 = MatrixOp(A2)
-opA3 = MatrixOp(A3)
-opH = HCAT(opA1, opA2, opA3)
-x1 = randn(n1)
-x2 = randn(n2)
-x3 = randn(n3)
-y1 = test_op(opH, (x1, x2, x3), randn(m), verb)
-y2 = A1*x1 + A2*x2 + A3*x3
-@test norm(y1-y2) <= 1e-12
-
-# test HCAT of HCAT
-opHH = HCAT(opH, opA2, opA3)
-y1 = test_op(opHH, (x1, x2, x3, x2, x3), randn(m), verb)
-y2 = A1*x1 + A2*x2 + A3*x3 + A2*x2 + A3*x3
-@test norm(y1-y2) <= 1e-12
-
-opHH = HCAT(opH, opH, opA3)
-x = (x1, x2, x3, x1, x2, x3, x3)
-y1 = test_op(opHH, x, randn(m), verb)
-y2 = A1*x1 + A2*x2 + A3*x3 + A1*x1 + A2*x2 + A3*x3 + A3*x3
-@test norm(y1-y2) <= 1e-12
-
-opA3 = MatrixOp(randn(n1,n1))
-@test_throws Exception HCAT(opA1,opA2,opA3)
-opF = AbstractOperators.DFT(Complex{Float64},(m,))
-@test_throws Exception HCAT(opA1,opF,opA2)
-
-# test utilities
-
-# permutation
-p = randperm(ndoms(opHH,2))
-opHP = AbstractOperators.permute(opHH,p)
-
-xp = x[p] 
-
-y1 = test_op(opHP, xp, randn(m), verb)
-
-pp = randperm(ndoms(opHH,2))
-opHPP = AbstractOperators.permute(opHH,pp)
-xpp = x[pp] 
-y1 = test_op(opHPP, xpp, randn(m), verb)
-
-#properties
-m, n1, n2, n3 = 4, 7, 5, 6
-A1 = randn(m, n1)
-A2 = randn(m, n2)
-A3 = randn(m, n3)
-opA1 = MatrixOp(A1)
-opA2 = MatrixOp(A2)
-opA3 = MatrixOp(A3)
-op = HCAT(opA1, opA2, opA3)
-@test is_linear(op)           == true
-@test is_null(op)             == false
-@test is_eye(op)              == false
-@test is_diagonal(op)         == false
-@test is_AcA_diagonal(op)     == false
-@test is_AAc_diagonal(op)     == false
-@test is_orthogonal(op)       == false
-@test is_invertible(op)       == false
-@test is_full_row_rank(op)    == true
-@test is_full_column_rank(op) == false
-
-d = randn(n1).+im.*randn(n1)
-op = HCAT(DiagOp(d), AbstractOperators.DFT(Complex{Float64},n1))
-@test is_null(op)             == false
-@test is_eye(op)              == false
-@test is_diagonal(op)         == false
-@test is_AcA_diagonal(op)     == false
-@test is_AAc_diagonal(op)     == true
-@test is_orthogonal(op)       == false
-@test is_invertible(op)       == false
-@test is_full_row_rank(op)    == true
-@test is_full_column_rank(op) == false
-
-@test diag_AAc(op) == d .* conj(d) .+ n1
-
-y1 = randn(n1) .+ im .* randn(n1)
-@test norm(op*(op'*y1).-diag_AAc(op).*y1) <1e-12
-
-#test displacement
-
-m, n1, n2 = 4, 7, 5
-A1 = randn(m, n1)
-A2 = randn(m, n2)
-d1 = randn(m)
-d2 = randn(m)
-opA1 = AffineAdd(MatrixOp(A1), d1)
-opA2 = AffineAdd(MatrixOp(A2), d2)
-opH = HCAT(opA1, opA2)
-x1 = randn(n1)
-x2 = randn(n2)
-y1 = opH*(x1,x2)
-y2 = A1*x1+d1 + A2*x2+d2
-@test norm(y1-y2) <= 1e-12
-y1 = remove_displacement(opH)*(x1,x2)
-y2 = A1*x1 + A2*x2
-@test norm(y1-y2) <= 1e-12
+y1 = opD*ArrayPartition(x1,x2,x3)
+y2 = ArrayPartition(A1*x1+d1, A2*x2+d2, A3*x3+d3)
+@test norm(y1 .- y2) .<= 1e-12
+@test norm(displacement(opD) .- ArrayPartition(d1,d2,d3)) .<= 1e-12
+y1 = remove_displacement(opD)*ArrayPartition(x1,x2,x3)
+y2 = ArrayPartition(A1*x1, A2*x2, A3*x3)
+@test norm(y1 .- y2) .<= 1e-12
 
 ########################
-### test Reshape #######
+### test HCAT    #######
 ########################
-
-m, n = 8, 4
-dim_out = (2, 2, 2)
-A1 = randn(m, n)
-opA1 = MatrixOp(A1)
-opR = Reshape(opA1, dim_out)
-opR = Reshape(opA1, dim_out...)
-x1 = randn(n)
-y1 = test_op(opR, x1, randn(dim_out), verb)
-y2 = reshape(A1*x1, dim_out)
-@test norm(y1-y2) <= 1e-12
-
-@test_throws Exception Reshape(opA1,(2,2,1))
-
-@test is_null(opR)             == is_null(opA1)            
-@test is_eye(opR)              == is_eye(opA1)             
-@test is_diagonal(opR)         == is_diagonal(opA1)        
-@test is_AcA_diagonal(opR)     == is_AcA_diagonal(opA1)    
-@test is_AAc_diagonal(opR)     == is_AAc_diagonal(opA1)    
-@test is_orthogonal(opR)       == is_orthogonal(opA1)      
-@test is_invertible(opR)       == is_invertible(opA1)      
-@test is_full_row_rank(opR)    == is_full_row_rank(opA1)   
-@test is_full_column_rank(opR) == is_full_column_rank(opA1)
-
-# testing displacement
-m, n = 8, 4
-dim_out = (2, 2, 2)
-A1 = randn(m, n)
-d1 = randn(m)
-opA1 = AffineAdd(MatrixOp(A1),d1)
-opR = Reshape(opA1, dim_out)
-x1 = randn(n)
-y1 = opR*x1
-y2 = reshape(A1*x1+d1, dim_out)
-@test norm(y1-y2) <= 1e-12
-y1 = remove_displacement(opR)*x1
-y2 = reshape(A1*x1, dim_out)
-@test norm(y1-y2) <= 1e-12
-
-#######################
-## test Scale   #######
-#######################
-
-m, n = 8, 4
-coeff = pi
-A1 = randn(m, n)
-opA1 = MatrixOp(A1)
-opS = Scale(coeff, opA1)
-x1 = randn(n)
-y1 = test_op(opS, x1, randn(m), verb)
-y2 = coeff*A1*x1
-@test norm(y1-y2) <= 1e-12
-
-coeff2 = 3
-opS2 = Scale(coeff2, opS)
-y1 = test_op(opS2, x1, randn(m), verb)
-y2 = coeff2*coeff*A1*x1
-@test norm(y1-y2) <= 1e-12
-
-opF = AbstractOperators.DFT(m,n)
-opS = Scale(coeff, opF)
-x1 = randn(m,n)
-y1 = test_op(opS, x1, fft(randn(m,n)), verb)
-y2 = coeff*(fft(x1))
-@test norm(y1-y2) <= 1e-12
-
-opS = Scale(coeff, opA1)
-@test is_null(opS)             == is_null(opA1)            
-@test is_eye(opS)              == is_eye(opA1)             
-@test is_diagonal(opS)         == is_diagonal(opA1)        
-@test is_AcA_diagonal(opS)     == is_AcA_diagonal(opA1)    
-@test is_AAc_diagonal(opS)     == is_AAc_diagonal(opA1)    
-@test is_orthogonal(opS)       == is_orthogonal(opA1)      
-@test is_invertible(opS)       == is_invertible(opA1)      
-@test is_full_row_rank(opS)    == is_full_row_rank(opA1)   
-@test is_full_column_rank(opS) == is_full_column_rank(opA1)
-
-op = Scale(-4.0,AbstractOperators.DFT(10))
-@test is_AAc_diagonal(op)     == true
-@test diag_AAc(op) == 16*10
-
-op = Scale(-4.0,ZeroPad((10,), 20))
-@test is_AcA_diagonal(op)     == true
-@test diag_AcA(op) == 16
-
-# special case, Scale of DiagOp gets a DiagOp
-d = randn(10)
-op = Scale(3,DiagOp(d))
-@test typeof(op) <: DiagOp
-@test norm(diag(op) - 3 .*d) < 1e-12
-
-# Scale with imaginary coeff gives error
-m, n = 8, 4
-coeff = im
-A1 = randn(m, n)
-opA1 = MatrixOp(A1)
-@test_throws ErrorException Scale(coeff, opA1)
-
-## testing displacement
-m, n = 8, 4
-coeff = pi
-A1 = randn(m, n)
-d1 = randn(m)
-opA1 = AffineAdd(MatrixOp(A1),d1)
-opS = Scale(coeff, opA1)
-x1 = randn(n)
-y1 = opS*x1
-y2 = coeff*(A1*x1+d1)
-@test norm(y1-y2) <= 1e-12
-y1 = remove_displacement(opS)*x1
-y2 = coeff*(A1*x1)
-@test norm(y1-y2) <= 1e-12
-
-#########################
-#### test Sum     #######
-#########################
-
-m,n = 5,7
-A1 = randn(m,n)
-A2 = randn(m,n)
-opA1 = MatrixOp(A1)
-opA2 = MatrixOp(A2)
-opS = Sum(opA1,opA2)
-x1 = randn(n)
-y1 = test_op(opS, x1, randn(m), verb)
-y2 = A1*x1+A2*x1
-@test norm(y1-y2) <= 1e-12
-
-#test Sum longer
-m,n = 5,7
-A1 = randn(m,n)
-A2 = randn(m,n)
-A3 = randn(m,n)
-opA1 = MatrixOp(A1)
-opA2 = MatrixOp(A2)
-opA3 = MatrixOp(A3)
-opS = Sum(opA1,opA2,opA3)
-x1 = randn(n)
-y1 = test_op(opS, x1, randn(m), verb)
-y2 = A1*x1+A2*x1+A3*x1
-@test norm(y1-y2) <= 1e-12
-
-opA3 = MatrixOp(randn(m,m))
-@test_throws Exception Sum(opA1,opA3)
-opF = AbstractOperators.DFT(Float64,(m,))
-@test_throws Exception Sum(opF,opA3)
-
-@test is_null(opS)             == false
-@test is_eye(opS)              == false 
-@test is_diagonal(opS)         == false
-@test is_AcA_diagonal(opS)     == false
-@test is_AAc_diagonal(opS)     == false
-@test is_orthogonal(opS)       == false
-@test is_invertible(opS)       == false
-@test is_full_row_rank(opS)    == true
-@test is_full_column_rank(opS) == false
-
-d = randn(10)
-op = Sum(Scale(-3.1,Eye(10)),DiagOp(d))
-@test is_diagonal(op)         == true
-@test norm(   diag(op) - (d .-3.1)  )<1e-12
-
-#test displacement of sum
-m,n = 5,7
-A1 = randn(m,n)
-A2 = randn(m,n)
-A3 = randn(m,n)
-d1 = randn(m)
-d2 = pi
-d3 = randn(m)
-opA1 = AffineAdd(MatrixOp(A1), d1) 
-opA2 = AffineAdd(MatrixOp(A2), d2)
-opA3 = AffineAdd(MatrixOp(A3), d3) 
-opS = Sum(opA1,opA2,opA3)
-x1 = randn(n)
-y2 = A1*x1+A2*x1+A3*x1+d1.+d2+d3
-@test norm(opS*x1-y2) <= 1e-12
-@test norm(displacement(opS) - (d1.+d2+d3)) <= 1e-12
-y2 = A1*x1+A2*x1+A3*x1
-@test norm(remove_displacement(opS)*x1-y2) <= 1e-12
-
-###################################
-###### test AdjointOperator #######
-###################################
-
-m,n = 5,7
-A1 = randn(m,n)
-opA1 = MatrixOp(A1)
-opA1t = MatrixOp(A1')
-opT = AdjointOperator(opA1)
-x1 = randn(m)
-y1 = test_op(opT, x1, randn(n), verb)
-y2 = A1'*x1
-@test norm(y1-y2) <= 1e-12
-
-@test is_null(opT)             == is_null(opA1t)            
-@test is_eye(opT)              == is_eye(opA1t)             
-@test is_diagonal(opT)         == is_diagonal(opA1t)        
-@test is_AcA_diagonal(opT)     == is_AcA_diagonal(opA1t)    
-@test is_AAc_diagonal(opT)     == is_AAc_diagonal(opA1t)    
-@test is_orthogonal(opT)       == is_orthogonal(opA1t)      
-@test is_invertible(opT)       == is_invertible(opA1t)      
-@test is_full_row_rank(opT)    == is_full_row_rank(opA1t)   
-@test is_full_column_rank(opT) == is_full_column_rank(opA1t)
-
-d = randn(3)
-op = AdjointOperator(DiagOp(d))
-@test is_diagonal(op) == true
-@test diag(op) == d
-
-op = AdjointOperator(ZeroPad((10,),5))
-@test is_AcA_diagonal(op) == false
-@test is_AAc_diagonal(op) == true
-@test diag_AAc(op) == 1
-
-#############################
-######## test VCAT    #######
-#############################
-
-m1, m2, n = 4, 7, 5
-A1 = randn(m1, n)
-A2 = randn(m2, n)
-opA1 = MatrixOp(A1)
-opA2 = MatrixOp(A2)
-opV = VCAT(opA1, opA2)
-x1 = randn(n)
-y1 = test_op(opV, x1, (randn(m1), randn(m2)), verb)
-y2 = (A1*x1, A2*x1)
-@test all(norm.(y1 .- y2) .<= 1e-12)
-
-m1, n = 4, 5
-A1 = randn(m1, n)+im*randn(m1, n)
-opA1 = MatrixOp(A1)
-opA2 = AbstractOperators.DFT(n)'
-opV = VCAT(opA1, opA2)
-x1 = randn(n)+im*randn(n)
-y1 = test_op(opV, x1, (randn(m1)+im*randn(m1), randn(n)), verb)
-y2 = (A1*x1, opA2*x1)
-@test all(norm.(y1 .- y2) .<= 1e-12)
-
-#test VCAT longer
-m1, m2, m3, n = 4, 7, 3, 5
-A1 = randn(m1, n)
-A2 = randn(m2, n)
-A3 = randn(m3, n)
-opA1 = MatrixOp(A1)
-opA2 = MatrixOp(A2)
-opA3 = MatrixOp(A3)
-opV = VCAT(opA1, opA2, opA3)
-x1 = randn(n)
-y1 = test_op(opV, x1, (randn(m1), randn(m2), randn(m3)), verb)
-y2 = (A1*x1, A2*x1, A3*x1)
-@test all(norm.(y1 .- y2) .<= 1e-12)
-
-#test VCAT of VCAT
-opVV = VCAT(opV,opA3)
-y1 = test_op(opVV, x1, (randn(m1), randn(m2), randn(m3), randn(m3)), verb)
-y2 = (A1*x1, A2*x1, A3*x1, A3*x1)
-@test all(norm.(y1 .- y2) .<= 1e-12)
-
-opVV = VCAT(opA1,opV,opA3)
-y1 = test_op(opVV, x1, (randn(m1), randn(m1), randn(m2), randn(m3), randn(m3)), verb)
-y2 = (A1*x1, A1*x1, A2*x1, A3*x1, A3*x1)
-@test all(norm.(y1 .- y2) .<= 1e-12)
-
-opA3 = MatrixOp(randn(m1,m1))
-@test_throws Exception VCAT(opA1,opA2,opA3)
-opF = AbstractOperators.DFT(Complex{Float64},(n,))
-@test_throws Exception VCAT(opA1,opF,opA2)
-
-###properties
-m1, m2, m3, n = 4, 7, 3, 5
-A1 = randn(m1, n)
-A2 = randn(m2, n)
-A3 = randn(m3, n)
-opA1 = MatrixOp(A1)
-opA2 = MatrixOp(A2)
-opA3 = MatrixOp(A3)
-op = VCAT(opA1, opA2, opA3)
-@test is_linear(op)           == true
-@test is_null(op)             == false
-@test is_eye(op)              == false
-@test is_diagonal(op)         == false
-@test is_AcA_diagonal(op)     == false
-@test is_AAc_diagonal(op)     == false
-@test is_orthogonal(op)       == false
-@test is_invertible(op)       == false
-@test is_full_row_rank(op)    == false
-@test is_full_column_rank(op) == true
-
-op = VCAT(AbstractOperators.DFT(Complex{Float64},10), Eye(Complex{Float64},10) )
-@test is_AcA_diagonal(op)     == true
-@test diag_AcA(op) == 11
-
+#
+#m, n1, n2 = 4, 7, 5
+#A1 = randn(m, n1)
+#A2 = randn(m, n2)
+#opA1 = MatrixOp(A1)
+#opA2 = MatrixOp(A2)
+#opH = HCAT(opA1, opA2)
+#x1 = randn(n1)
+#x2 = randn(n2)
+#y1 = test_op(opH, (x1, x2), randn(m), verb)
+#y2 = A1*x1 + A2*x2
+#@test norm(y1-y2) <= 1e-12
+#
+##permuatation 
+#p = [2;1]
+#opHp = opH[p]
+#y1 = test_op(opHp, (x2, x1), randn(m), verb)
+#@test norm(y1-y2) <= 1e-12
+#
+## test HCAT longer
+#
+#m, n1, n2, n3 = 4, 7, 5, 6
+#A1 = randn(m, n1)
+#A2 = randn(m, n2)
+#A3 = randn(m, n3)
+#opA1 = MatrixOp(A1)
+#opA2 = MatrixOp(A2)
+#opA3 = MatrixOp(A3)
+#opH = HCAT(opA1, opA2, opA3)
+#x1 = randn(n1)
+#x2 = randn(n2)
+#x3 = randn(n3)
+#y1 = test_op(opH, (x1, x2, x3), randn(m), verb)
+#y2 = A1*x1 + A2*x2 + A3*x3
+#@test norm(y1-y2) <= 1e-12
+#
+## test HCAT of HCAT
+#opHH = HCAT(opH, opA2, opA3)
+#y1 = test_op(opHH, (x1, x2, x3, x2, x3), randn(m), verb)
+#y2 = A1*x1 + A2*x2 + A3*x3 + A2*x2 + A3*x3
+#@test norm(y1-y2) <= 1e-12
+#
+#opHH = HCAT(opH, opH, opA3)
+#x = (x1, x2, x3, x1, x2, x3, x3)
+#y1 = test_op(opHH, x, randn(m), verb)
+#y2 = A1*x1 + A2*x2 + A3*x3 + A1*x1 + A2*x2 + A3*x3 + A3*x3
+#@test norm(y1-y2) <= 1e-12
+#
+#opA3 = MatrixOp(randn(n1,n1))
+#@test_throws Exception HCAT(opA1,opA2,opA3)
+#opF = AbstractOperators.DFT(Complex{Float64},(m,))
+#@test_throws Exception HCAT(opA1,opF,opA2)
+#
+## test utilities
+#
+## permutation
+#p = randperm(ndoms(opHH,2))
+#opHP = AbstractOperators.permute(opHH,p)
+#
+#xp = x[p] 
+#
+#y1 = test_op(opHP, xp, randn(m), verb)
+#
+#pp = randperm(ndoms(opHH,2))
+#opHPP = AbstractOperators.permute(opHH,pp)
+#xpp = x[pp] 
+#y1 = test_op(opHPP, xpp, randn(m), verb)
+#
+##properties
+#m, n1, n2, n3 = 4, 7, 5, 6
+#A1 = randn(m, n1)
+#A2 = randn(m, n2)
+#A3 = randn(m, n3)
+#opA1 = MatrixOp(A1)
+#opA2 = MatrixOp(A2)
+#opA3 = MatrixOp(A3)
+#op = HCAT(opA1, opA2, opA3)
+#@test is_linear(op)           == true
+#@test is_null(op)             == false
+#@test is_eye(op)              == false
+#@test is_diagonal(op)         == false
+#@test is_AcA_diagonal(op)     == false
+#@test is_AAc_diagonal(op)     == false
+#@test is_orthogonal(op)       == false
+#@test is_invertible(op)       == false
+#@test is_full_row_rank(op)    == true
+#@test is_full_column_rank(op) == false
+#
+#d = randn(n1).+im.*randn(n1)
+#op = HCAT(DiagOp(d), AbstractOperators.DFT(Complex{Float64},n1))
+#@test is_null(op)             == false
+#@test is_eye(op)              == false
+#@test is_diagonal(op)         == false
+#@test is_AcA_diagonal(op)     == false
+#@test is_AAc_diagonal(op)     == true
+#@test is_orthogonal(op)       == false
+#@test is_invertible(op)       == false
+#@test is_full_row_rank(op)    == true
+#@test is_full_column_rank(op) == false
+#
+#@test diag_AAc(op) == d .* conj(d) .+ n1
+#
+#y1 = randn(n1) .+ im .* randn(n1)
+#@test norm(op*(op'*y1).-diag_AAc(op).*y1) <1e-12
+#
 ##test displacement
-m1, m2, n = 4, 7, 5
-A1 = randn(m1, n)
-A2 = randn(m2, n)
-opA1 = MatrixOp(A1)
-opA2 = MatrixOp(A2)
-d1 = randn(m1)
-d2 = randn(m2)
-opV = VCAT(AffineAdd(opA1,d1), AffineAdd(opA2,d2))
-x1 = randn(n)
-y1 = opV*x1
-y2 = (A1*x1+d1, A2*x1+d2)
-@test all(norm.(y1 .- y2) .<= 1e-12)
-y1 = remove_displacement(opV)*x1
-y2 = (A1*x1, A2*x1)
-@test all(norm.(y1 .- y2) .<= 1e-12)
-
+#
+#m, n1, n2 = 4, 7, 5
+#A1 = randn(m, n1)
+#A2 = randn(m, n2)
+#d1 = randn(m)
+#d2 = randn(m)
+#opA1 = AffineAdd(MatrixOp(A1), d1)
+#opA2 = AffineAdd(MatrixOp(A2), d2)
+#opH = HCAT(opA1, opA2)
+#x1 = randn(n1)
+#x2 = randn(n2)
+#y1 = opH*(x1,x2)
+#y2 = A1*x1+d1 + A2*x2+d2
+#@test norm(y1-y2) <= 1e-12
+#y1 = remove_displacement(opH)*(x1,x2)
+#y2 = A1*x1 + A2*x2
+#@test norm(y1-y2) <= 1e-12
+#
 #########################
-#### test BroadCast #####
+#### test Reshape #######
 #########################
-
-m, n = 8, 4
-dim_out = (m, 10)
-A1 = randn(m, n)
-opA1 = MatrixOp(A1)
-opR = BroadCast(opA1, dim_out)
-x1 = randn(n)
-y1 = test_op(opR, x1, randn(dim_out), verb)
-y2 = zeros(dim_out)
-y2 .= A1*x1
-@test norm(y1-y2) <= 1e-12
-
-m, n, l, k = 8, 4, 5, 7
-dim_out = (m, n, l, k)
-opA1 = Eye(m,n)
-opR = BroadCast(opA1, dim_out)
-x1 = randn(m,n)
-y1 = test_op(opR, x1, randn(dim_out), verb)
-y2 = zeros(dim_out)
-y2 .= x1
-@test norm(y1-y2) <= 1e-12
-
-@test_throws Exception BroadCast(opA1,(m,m))
-
-m, l = 1, 5
-dim_out = (m, l)
-opA1 = Eye(m)
-opR = BroadCast(opA1, dim_out)
-x1 = randn(m)
-y1 = test_op(opR, x1, randn(dim_out), verb)
-y2 = zeros(dim_out)
-y2 .= x1
-@test norm(y1-y2) <= 1e-12
-
-#colum in - matrix out
-m, l = 4, 5
-dim_out = (m, l)
-opA1 = Eye(1,l)
-opR = BroadCast(opA1, dim_out)
-x1 = randn(1,l)
-y1 = test_op(opR, x1, randn(dim_out), verb)
-y2 = zeros(dim_out)
-y2 .= x1
-@test norm(y1-y2) <= 1e-12
-
-op = HCAT(Eye(m,l),opR)
-x1 = (randn(m,l),randn(1,l))
-y1 = test_op(op, x1, randn(dim_out), verb)
-y2 = x1[1].+x1[2]
-@test norm(y1-y2) <= 1e-12
-
-m, n, l  = 2, 5, 8
-dim_out = (m, n, l)
-opA1 = Eye(m)
-opR = BroadCast(opA1, dim_out)
-x1 = randn(m)
-y1 = test_op(opR, x1, randn(dim_out), verb)
-y2 = zeros(dim_out)
-y2 .= x1
-@test norm(y1-y2) <= 1e-12
-
-m, n, l  = 1, 5, 8
-dim_out = (m, n, l)
-opA1 = Eye(m)
-opR = BroadCast(opA1, dim_out)
-x1 = randn(m)
-y1 = test_op(opR, x1, randn(dim_out), verb)
-y2 = zeros(dim_out)
-y2 .= x1
-@test norm(y1-y2) <= 1e-12
-
-m, n, l  = 1, 5, 8
-dim_out = (m, n, l)
-opA1 = Scale(2.4,Eye(m))
-opR = BroadCast(opA1, dim_out)
-x1 = randn(m)
-y1 = test_op(opR, x1, randn(dim_out), verb)
-y2 = zeros(dim_out)
-y2 .= 2.4*x1
-@test norm(y1-y2) <= 1e-12
-
-@test is_null(opR)             == is_null(opA1)            
-@test is_eye(opR)              == false             
-@test is_diagonal(opR)         == false 
-@test is_AcA_diagonal(opR)     == false
-@test is_AAc_diagonal(opR)     == false
-@test is_orthogonal(opR)       == false
-@test is_invertible(opR)       == false
-@test is_full_row_rank(opR)    == false
-@test is_full_column_rank(opR) == false
-
-# test displacement
-
-m, n = 8, 4
-dim_out = (m, 10)
-A1 = randn(m, n)
-d1 = randn(m)
-opA1 = AffineAdd(MatrixOp(A1), d1)
-opR = BroadCast(opA1, dim_out)
-x1 = randn(n)
-y1 = opR*x1
-y2 = zeros(dim_out)
-y2 .= A1*x1+d1
-@test norm(y1-y2) <= 1e-12
-x1 = randn(n)
-y1 = remove_displacement(opR)*x1
-y2 = zeros(dim_out)
-y2 .= A1*x1
-@test norm(y1-y2) <= 1e-12
-
-###########################
-##### test AffineAdd  #####
-###########################
-
-n,m = 5,6
-A = randn(n,m)
-opA = MatrixOp(A)
-d = randn(n)
-T = AffineAdd(opA,d)
-
-println(T)
-x1 = randn(m)
-y1 = T*x1
-@test norm(y1-(A*x1+d)) <1e-9
-r = randn(n)
-@test norm(T'*r-(A'*r)) <1e-9
-@test displacement(T) == d
-@test norm(remove_displacement(T)*x1-A*x1) <1e-9
-
-# with sign
-T = AffineAdd(opA,d,false)
-@test sign(T) == -1
-
-println(T)
-x1 = randn(m)
-y1 = T*x1
-@test norm(y1-(A*x1-d)) <1e-9
-r = randn(n)
-@test norm(T'*r-(A'*r)) <1e-9
-@test displacement(T) == -d
-@test norm(remove_displacement(T)*x1-A*x1) <1e-9
-
-# with scalar
-T = AffineAdd(opA,pi)
-@test sign(T) == 1
-
-println(T)
-x1 = randn(m)
-y1 = T*x1
-@test norm(y1-(A*x1.+pi)) <1e-9
-r = randn(n)
-@test norm(T'*r-(A'*r)) < 1e-9
-@test displacement(T) .- pi < 1e-9
-@test norm(remove_displacement(T)*x1-A*x1) <1e-9
-
-@test_throws DimensionMismatch AffineAdd(MatrixOp(randn(2,5)),randn(5))
-@test_throws ErrorException AffineAdd(AbstractOperators.DFT(4),randn(4))
-AffineAdd(AbstractOperators.DFT(4),pi)
-@test_throws ErrorException AffineAdd(Eye(4),im*pi)
-
-# with scalar and vector 
-d = randn(n) 
-T = AffineAdd(AffineAdd(opA,pi),d,false)
-
-println(T)
-x1 = randn(m)
-y1 = T*x1
-@test norm(y1-(A*x1 .+ pi .- d)) <1e-9
-r = randn(n)
-@test norm(T'*r-(A'*r)) < 1e-9
-@test norm(displacement(T) .- (pi .-d )) < 1e-9
-
-T2 = remove_displacement(T)
-@test norm(T2*x1-(A*x1)) <1e-9
-
-# permute AddAffine 
-n,m = 5,6
-A = randn(n,m)
-d = randn(n)
-opH = HCAT(Eye(n),MatrixOp(A))
-x = (randn(n),randn(m))
-opHT = AffineAdd(opH,d)
-
-@test norm(opHT*x-(x[1]+A*x[2].+d)) < 1e-12
-p = [2;1]
-@test norm(AbstractOperators.permute(opHT,p)*x[p]-(x[1]+A*x[2].+d)) < 1e-12
-
-#############################
-######## test combin. #######
-#############################
-
-## test Compose of HCAT
-m1, m2, m3, m4 = 4, 7, 3, 2
-A1 = randn(m3, m1)
-A2 = randn(m3, m2)
-A3 = randn(m4, m3)
-opA1 = MatrixOp(A1)
-opA2 = MatrixOp(A2)
-opA3 = MatrixOp(A3)
-opH = HCAT(opA1,opA2)
-opC = Compose(opA3,opH)
-x1, x2 = randn(m1), randn(m2)
-y1 = test_op(opC, (x1,x2), randn(m4), verb)
-
-y2 = A3*(A1*x1+A2*x2)
-
-@test norm(y1-y2) < 1e-9
-
-opCp = AbstractOperators.permute(opC,[2,1])
-y1 = test_op(opCp, (x2,x1), randn(m4), verb)
-
-@test norm(y1-y2) < 1e-9
-
-## test HCAT of Compose of HCAT
-m5 = 10
-A4 = randn(m4,m5)
-x3 = randn(m5)
-opHC = HCAT(opC,MatrixOp(A4))
-x = (x1,x2,x3)
-y1 = test_op(opHC, x, randn(m4), verb)
-
-@test norm(y1-(y2+A4*x3)) < 1e-9
-
-p = randperm(ndoms(opHC,2))
-opHP = AbstractOperators.permute(opHC,p)
-
-xp = x[p] 
-
-y1 = test_op(opHP, xp, randn(m4), verb)
-
-pp = randperm(ndoms(opHC,2))
-opHPP = AbstractOperators.permute(opHC,pp)
-xpp = x[pp] 
-y1 = test_op(opHPP, xpp, randn(m4), verb)
-
-
-# test VCAT of HCAT's
-m1, m2, n1 = 4, 7, 3
-A1 = randn(n1, m1)
-A2 = randn(n1, m2)
-opA1 = MatrixOp(A1)
-opA2 = MatrixOp(A2)
-opH1 = HCAT(opA1,opA2)
-
-m1, m2, n2 = 4, 7, 5
-A3 = randn(n2, m1)
-A4 = randn(n2, m2)
-opA3 = MatrixOp(A3)
-opA4 = MatrixOp(A4)
-opH2 = HCAT(opA3,opA4)
-
-opV = VCAT(opH1,opH2)
-x1, x2 = randn(m1), randn(m2)
-y1 = test_op(opV, (x1,x2), (randn(n1),randn(n2)), verb)
-y2 = (A1*x1+A2*x2,A3*x1+A4*x2)
-@test all(norm.(y1 .- y2) .<= 1e-12)
-
-# test VCAT of HCAT's with complex num
-m1, m2, n1 = 4, 7, 5
-A1 = randn(n1, m1)+im*randn(n1, m1)
-opA1 = MatrixOp(A1)
-opA2 = AbstractOperators.DFT(n1)
-opH1 = HCAT(opA1,opA2)
-
-m1, m2, n2 = 4, 7, 5
-A3 = randn(n2, m1)+im*randn(n2,m1)
-opA3 = MatrixOp(A3)
-opA4 = AbstractOperators.DFT(n2)
-opH2 = HCAT(opA3,opA4)
-
-opV = VCAT(opH1,opH2)
-x1, x2 = randn(m1)+im*randn(m1), randn(n2)
-y1 = test_op(opV, (x1,x2), (randn(n1)+im*randn(n1),randn(n2)+im*randn(n2)), verb)
-y2 = (A1*x1+fft(x2),A3*x1+fft(x2))
-@test all(norm.(y1 .- y2) .<= 1e-12)
-
-# test HCAT of VCAT's
-
-n1, n2, m1, m2 = 3, 5, 4, 7
-A = randn(m1, n1); opA = MatrixOp(A)
-B = randn(m1, n2); opB = MatrixOp(B)
-C = randn(m2, n1); opC = MatrixOp(C)
-D = randn(m2, n2); opD = MatrixOp(D)
-opV = HCAT(VCAT(opA, opC), VCAT(opB, opD))
-x1 = randn(n1)
-x2 = randn(n2)
-y1 = test_op(opV, (x1, x2), (randn(m1), randn(m2)), verb)
-y2 = (A*x1 + B*x2, C*x1 + D*x2)
-
-@test all(norm.(y1 .- y2) .<= 1e-12)
-
-# test Sum of HCAT's
-
-m, n1, n2, n3 = 4, 7, 5, 3
-A1 = randn(m, n1)
-A2 = randn(m, n2)
-A3 = randn(m, n3)
-B1 = randn(m, n1)
-B2 = randn(m, n2)
-B3 = randn(m, n3)
-opA1 = MatrixOp(A1)
-opA2 = MatrixOp(A2)
-opA3 = MatrixOp(A3)
-opB1 = MatrixOp(B1)
-opB2 = MatrixOp(B2)
-opB3 = MatrixOp(B3)
-opHA = HCAT(opA1, opA2, opA3)
-opHB = HCAT(opB1, opB2, opB3)
-opS = Sum(opHA, opHB)
-x1 = randn(n1)
-x2 = randn(n2)
-x3 = randn(n3)
-y1 = test_op(opS, (x1, x2, x3), randn(m), verb)
-y2 = A1*x1 + B1*x1 + A2*x2 + B2*x2 + A3*x3 + B3*x3
-
-@test norm(y1-y2) <= 1e-12
-
-p = [3;2;1]
-opSp = AbstractOperators.permute(opS,p)
-y1 = test_op(opSp, (x1, x2, x3)[p], randn(m), verb)
-
-# test Sum of VCAT's
-
-m1, m2, n = 4, 7, 5
-A1 = randn(m1, n)
-A2 = randn(m2, n)
-B1 = randn(m1, n)
-B2 = randn(m2, n)
-C1 = randn(m1, n)
-C2 = randn(m2, n)
-opA1 = MatrixOp(A1)
-opA2 = MatrixOp(A2)
-opB1 = MatrixOp(B1)
-opB2 = MatrixOp(B2)
-opC1 = MatrixOp(C1)
-opC2 = MatrixOp(C2)
-opVA = VCAT(opA1, opA2)
-opVB = VCAT(opB1, opB2)
-opVC = VCAT(opC1, opC2)
-opS = Sum(opVA, opVB, opVC)
-x = randn(n)
-y1 = test_op(opS, x, (randn(m1), randn(m2)), verb)
-y2 = (A1*x + B1*x +C1*x, A2*x + B2*x + C2*x)
-
-@test all(norm.(y1 .- y2) .<= 1e-12)
-
-# test Scale of DCAT
-
-m1, n1 = 4, 7
-m2, n2 = 3, 5
-A1 = randn(m1, n1)
-A2 = randn(m2, n2)
-opA1 = MatrixOp(A1)
-opA2 = MatrixOp(A2)
-opD = DCAT(opA1, opA2)
-coeff = randn()
-opS = Scale(coeff, opD)
-x1 = randn(n1)
-x2 = randn(n2)
-y = test_op(opS, (x1, x2), (randn(m1), randn(m2)), verb)
-z = (coeff*A1*x1, coeff*A2*x2)
-
-@test all(norm.(y .- z) .<= 1e-12)
-
-# test Scale of VCAT
-
-m1, m2, n = 4, 3, 7
-A1 = randn(m1, n)
-A2 = randn(m2, n)
-opA1 = MatrixOp(A1)
-opA2 = MatrixOp(A2)
-opV = VCAT(opA1, opA2)
-coeff = randn()
-opS = Scale(coeff, opV)
-x = randn(n)
-y = test_op(opS, x, (randn(m1), randn(m2)), verb)
-z = (coeff*A1*x, coeff*A2*x)
-
-@test all(norm.(y .- z) .<= 1e-12)
-
-# test Scale of HCAT
-
-m, n1, n2 = 4, 3, 7
-A1 = randn(m, n1)
-A2 = randn(m, n2)
-opA1 = MatrixOp(A1)
-opA2 = MatrixOp(A2)
-opH = HCAT(opA1, opA2)
-coeff = randn()
-opS = Scale(coeff, opH)
-x1 = randn(n1)
-x2 = randn(n2)
-y = test_op(opS, (x1, x2), randn(m), verb)
-z = coeff*(A1*x1 + A2*x2)
-
-@test all(norm.(y .- z) .<= 1e-12)
-
-# test DCAT of HCATs
-
-m1, m2, n1, n2, l1, l2, l3 = 2,3,4,5,6,7,8
-A1 = randn(m1, n1)
-A2 = randn(m1, n2)
-B1 = randn(m2, n1)
-B2 = randn(m2, n2)
-B3 = randn(m2, n2)
-opA1 = MatrixOp(A1)
-opA2 = MatrixOp(A2)
-opH1 = HCAT(opA1, opA2)
-opB1 = MatrixOp(B1)
-opB2 = MatrixOp(B2)
-opB3 = MatrixOp(B3)
-opH2 = HCAT(opB1, opB2, opB3)
-
-op = DCAT(opA1, opH2)
-x =  randn.(size(op,2))
-y0 = randn.(size(op,1))
-y = test_op(op, x, y0, verb)
-
-op = DCAT(opH1, opH2)
-x =  randn.(size(op,2))
-y0 = randn.(size(op,1))
-y = test_op(op, x, y0, verb)
-
-p = randperm(ndoms(op,2))
-y2 = op[p]*x[p]
-
-@test AbstractOperators.blockvecnorm(y .- y2) <= 1e-8
-
-# test Scale of Sum
-
-m,n = 5,7
-A1 = randn(m,n)
-A2 = randn(m,n)
-opA1 = MatrixOp(A1)
-opA2 = MatrixOp(A2)
-opS = Sum(opA1,opA2)
-coeff = pi
-opSS = Scale(coeff,opS)
-x1 = randn(n)
-y1 = test_op(opSS, x1, randn(m), verb)
-y2 = coeff*(A1*x1+A2*x1)
-@test norm(y1-y2) <= 1e-12
-
-# test Scale of Compose
-
-m1, m2, m3 = 4, 7, 3
-A1 = randn(m2, m1)
-A2 = randn(m3, m2)
-opA1 = MatrixOp(A1)
-opA2 = MatrixOp(A2)
-
-coeff = pi
-opC = Compose(opA2,opA1)
-opS = Scale(coeff,opC)
-x = randn(m1)
-y1 = test_op(opS, x, randn(m3), verb)
-y2 = coeff*(A2*A1*x)
-@test all(norm.(y1 .- y2) .<= 1e-12)
-
+#
+#m, n = 8, 4
+#dim_out = (2, 2, 2)
+#A1 = randn(m, n)
+#opA1 = MatrixOp(A1)
+#opR = Reshape(opA1, dim_out)
+#opR = Reshape(opA1, dim_out...)
+#x1 = randn(n)
+#y1 = test_op(opR, x1, randn(dim_out), verb)
+#y2 = reshape(A1*x1, dim_out)
+#@test norm(y1-y2) <= 1e-12
+#
+#@test_throws Exception Reshape(opA1,(2,2,1))
+#
+#@test is_null(opR)             == is_null(opA1)            
+#@test is_eye(opR)              == is_eye(opA1)             
+#@test is_diagonal(opR)         == is_diagonal(opA1)        
+#@test is_AcA_diagonal(opR)     == is_AcA_diagonal(opA1)    
+#@test is_AAc_diagonal(opR)     == is_AAc_diagonal(opA1)    
+#@test is_orthogonal(opR)       == is_orthogonal(opA1)      
+#@test is_invertible(opR)       == is_invertible(opA1)      
+#@test is_full_row_rank(opR)    == is_full_row_rank(opA1)   
+#@test is_full_column_rank(opR) == is_full_column_rank(opA1)
+#
+## testing displacement
+#m, n = 8, 4
+#dim_out = (2, 2, 2)
+#A1 = randn(m, n)
+#d1 = randn(m)
+#opA1 = AffineAdd(MatrixOp(A1),d1)
+#opR = Reshape(opA1, dim_out)
+#x1 = randn(n)
+#y1 = opR*x1
+#y2 = reshape(A1*x1+d1, dim_out)
+#@test norm(y1-y2) <= 1e-12
+#y1 = remove_displacement(opR)*x1
+#y2 = reshape(A1*x1, dim_out)
+#@test norm(y1-y2) <= 1e-12
+#
+########################
+### test Scale   #######
+########################
+#
+#m, n = 8, 4
+#coeff = pi
+#A1 = randn(m, n)
+#opA1 = MatrixOp(A1)
+#opS = Scale(coeff, opA1)
+#x1 = randn(n)
+#y1 = test_op(opS, x1, randn(m), verb)
+#y2 = coeff*A1*x1
+#@test norm(y1-y2) <= 1e-12
+#
+#coeff2 = 3
+#opS2 = Scale(coeff2, opS)
+#y1 = test_op(opS2, x1, randn(m), verb)
+#y2 = coeff2*coeff*A1*x1
+#@test norm(y1-y2) <= 1e-12
+#
+#opF = AbstractOperators.DFT(m,n)
+#opS = Scale(coeff, opF)
+#x1 = randn(m,n)
+#y1 = test_op(opS, x1, fft(randn(m,n)), verb)
+#y2 = coeff*(fft(x1))
+#@test norm(y1-y2) <= 1e-12
+#
+#opS = Scale(coeff, opA1)
+#@test is_null(opS)             == is_null(opA1)            
+#@test is_eye(opS)              == is_eye(opA1)             
+#@test is_diagonal(opS)         == is_diagonal(opA1)        
+#@test is_AcA_diagonal(opS)     == is_AcA_diagonal(opA1)    
+#@test is_AAc_diagonal(opS)     == is_AAc_diagonal(opA1)    
+#@test is_orthogonal(opS)       == is_orthogonal(opA1)      
+#@test is_invertible(opS)       == is_invertible(opA1)      
+#@test is_full_row_rank(opS)    == is_full_row_rank(opA1)   
+#@test is_full_column_rank(opS) == is_full_column_rank(opA1)
+#
+#op = Scale(-4.0,AbstractOperators.DFT(10))
+#@test is_AAc_diagonal(op)     == true
+#@test diag_AAc(op) == 16*10
+#
+#op = Scale(-4.0,ZeroPad((10,), 20))
+#@test is_AcA_diagonal(op)     == true
+#@test diag_AcA(op) == 16
+#
+## special case, Scale of DiagOp gets a DiagOp
+#d = randn(10)
+#op = Scale(3,DiagOp(d))
+#@test typeof(op) <: DiagOp
+#@test norm(diag(op) - 3 .*d) < 1e-12
+#
+## Scale with imaginary coeff gives error
+#m, n = 8, 4
+#coeff = im
+#A1 = randn(m, n)
+#opA1 = MatrixOp(A1)
+#@test_throws ErrorException Scale(coeff, opA1)
+#
+### testing displacement
+#m, n = 8, 4
+#coeff = pi
+#A1 = randn(m, n)
+#d1 = randn(m)
+#opA1 = AffineAdd(MatrixOp(A1),d1)
+#opS = Scale(coeff, opA1)
+#x1 = randn(n)
+#y1 = opS*x1
+#y2 = coeff*(A1*x1+d1)
+#@test norm(y1-y2) <= 1e-12
+#y1 = remove_displacement(opS)*x1
+#y2 = coeff*(A1*x1)
+#@test norm(y1-y2) <= 1e-12
+#
+##########################
+##### test Sum     #######
+##########################
+#
+#m,n = 5,7
+#A1 = randn(m,n)
+#A2 = randn(m,n)
+#opA1 = MatrixOp(A1)
+#opA2 = MatrixOp(A2)
+#opS = Sum(opA1,opA2)
+#x1 = randn(n)
+#y1 = test_op(opS, x1, randn(m), verb)
+#y2 = A1*x1+A2*x1
+#@test norm(y1-y2) <= 1e-12
+#
+##test Sum longer
+#m,n = 5,7
+#A1 = randn(m,n)
+#A2 = randn(m,n)
+#A3 = randn(m,n)
+#opA1 = MatrixOp(A1)
+#opA2 = MatrixOp(A2)
+#opA3 = MatrixOp(A3)
+#opS = Sum(opA1,opA2,opA3)
+#x1 = randn(n)
+#y1 = test_op(opS, x1, randn(m), verb)
+#y2 = A1*x1+A2*x1+A3*x1
+#@test norm(y1-y2) <= 1e-12
+#
+#opA3 = MatrixOp(randn(m,m))
+#@test_throws Exception Sum(opA1,opA3)
+#opF = AbstractOperators.DFT(Float64,(m,))
+#@test_throws Exception Sum(opF,opA3)
+#
+#@test is_null(opS)             == false
+#@test is_eye(opS)              == false 
+#@test is_diagonal(opS)         == false
+#@test is_AcA_diagonal(opS)     == false
+#@test is_AAc_diagonal(opS)     == false
+#@test is_orthogonal(opS)       == false
+#@test is_invertible(opS)       == false
+#@test is_full_row_rank(opS)    == true
+#@test is_full_column_rank(opS) == false
+#
+#d = randn(10)
+#op = Sum(Scale(-3.1,Eye(10)),DiagOp(d))
+#@test is_diagonal(op)         == true
+#@test norm(   diag(op) - (d .-3.1)  )<1e-12
+#
+##test displacement of sum
+#m,n = 5,7
+#A1 = randn(m,n)
+#A2 = randn(m,n)
+#A3 = randn(m,n)
+#d1 = randn(m)
+#d2 = pi
+#d3 = randn(m)
+#opA1 = AffineAdd(MatrixOp(A1), d1) 
+#opA2 = AffineAdd(MatrixOp(A2), d2)
+#opA3 = AffineAdd(MatrixOp(A3), d3) 
+#opS = Sum(opA1,opA2,opA3)
+#x1 = randn(n)
+#y2 = A1*x1+A2*x1+A3*x1+d1.+d2+d3
+#@test norm(opS*x1-y2) <= 1e-12
+#@test norm(displacement(opS) - (d1.+d2+d3)) <= 1e-12
+#y2 = A1*x1+A2*x1+A3*x1
+#@test norm(remove_displacement(opS)*x1-y2) <= 1e-12
+#
+####################################
+####### test AdjointOperator #######
+####################################
+#
+#m,n = 5,7
+#A1 = randn(m,n)
+#opA1 = MatrixOp(A1)
+#opA1t = MatrixOp(A1')
+#opT = AdjointOperator(opA1)
+#x1 = randn(m)
+#y1 = test_op(opT, x1, randn(n), verb)
+#y2 = A1'*x1
+#@test norm(y1-y2) <= 1e-12
+#
+#@test is_null(opT)             == is_null(opA1t)            
+#@test is_eye(opT)              == is_eye(opA1t)             
+#@test is_diagonal(opT)         == is_diagonal(opA1t)        
+#@test is_AcA_diagonal(opT)     == is_AcA_diagonal(opA1t)    
+#@test is_AAc_diagonal(opT)     == is_AAc_diagonal(opA1t)    
+#@test is_orthogonal(opT)       == is_orthogonal(opA1t)      
+#@test is_invertible(opT)       == is_invertible(opA1t)      
+#@test is_full_row_rank(opT)    == is_full_row_rank(opA1t)   
+#@test is_full_column_rank(opT) == is_full_column_rank(opA1t)
+#
+#d = randn(3)
+#op = AdjointOperator(DiagOp(d))
+#@test is_diagonal(op) == true
+#@test diag(op) == d
+#
+#op = AdjointOperator(ZeroPad((10,),5))
+#@test is_AcA_diagonal(op) == false
+#@test is_AAc_diagonal(op) == true
+#@test diag_AAc(op) == 1
+#
+##############################
+######### test VCAT    #######
+##############################
+#
+#m1, m2, n = 4, 7, 5
+#A1 = randn(m1, n)
+#A2 = randn(m2, n)
+#opA1 = MatrixOp(A1)
+#opA2 = MatrixOp(A2)
+#opV = VCAT(opA1, opA2)
+#x1 = randn(n)
+#y1 = test_op(opV, x1, (randn(m1), randn(m2)), verb)
+#y2 = (A1*x1, A2*x1)
+#@test all(norm.(y1 .- y2) .<= 1e-12)
+#
+#m1, n = 4, 5
+#A1 = randn(m1, n)+im*randn(m1, n)
+#opA1 = MatrixOp(A1)
+#opA2 = AbstractOperators.DFT(n)'
+#opV = VCAT(opA1, opA2)
+#x1 = randn(n)+im*randn(n)
+#y1 = test_op(opV, x1, (randn(m1)+im*randn(m1), randn(n)), verb)
+#y2 = (A1*x1, opA2*x1)
+#@test all(norm.(y1 .- y2) .<= 1e-12)
+#
+##test VCAT longer
+#m1, m2, m3, n = 4, 7, 3, 5
+#A1 = randn(m1, n)
+#A2 = randn(m2, n)
+#A3 = randn(m3, n)
+#opA1 = MatrixOp(A1)
+#opA2 = MatrixOp(A2)
+#opA3 = MatrixOp(A3)
+#opV = VCAT(opA1, opA2, opA3)
+#x1 = randn(n)
+#y1 = test_op(opV, x1, (randn(m1), randn(m2), randn(m3)), verb)
+#y2 = (A1*x1, A2*x1, A3*x1)
+#@test all(norm.(y1 .- y2) .<= 1e-12)
+#
+##test VCAT of VCAT
+#opVV = VCAT(opV,opA3)
+#y1 = test_op(opVV, x1, (randn(m1), randn(m2), randn(m3), randn(m3)), verb)
+#y2 = (A1*x1, A2*x1, A3*x1, A3*x1)
+#@test all(norm.(y1 .- y2) .<= 1e-12)
+#
+#opVV = VCAT(opA1,opV,opA3)
+#y1 = test_op(opVV, x1, (randn(m1), randn(m1), randn(m2), randn(m3), randn(m3)), verb)
+#y2 = (A1*x1, A1*x1, A2*x1, A3*x1, A3*x1)
+#@test all(norm.(y1 .- y2) .<= 1e-12)
+#
+#opA3 = MatrixOp(randn(m1,m1))
+#@test_throws Exception VCAT(opA1,opA2,opA3)
+#opF = AbstractOperators.DFT(Complex{Float64},(n,))
+#@test_throws Exception VCAT(opA1,opF,opA2)
+#
+####properties
+#m1, m2, m3, n = 4, 7, 3, 5
+#A1 = randn(m1, n)
+#A2 = randn(m2, n)
+#A3 = randn(m3, n)
+#opA1 = MatrixOp(A1)
+#opA2 = MatrixOp(A2)
+#opA3 = MatrixOp(A3)
+#op = VCAT(opA1, opA2, opA3)
+#@test is_linear(op)           == true
+#@test is_null(op)             == false
+#@test is_eye(op)              == false
+#@test is_diagonal(op)         == false
+#@test is_AcA_diagonal(op)     == false
+#@test is_AAc_diagonal(op)     == false
+#@test is_orthogonal(op)       == false
+#@test is_invertible(op)       == false
+#@test is_full_row_rank(op)    == false
+#@test is_full_column_rank(op) == true
+#
+#op = VCAT(AbstractOperators.DFT(Complex{Float64},10), Eye(Complex{Float64},10) )
+#@test is_AcA_diagonal(op)     == true
+#@test diag_AcA(op) == 11
+#
+###test displacement
+#m1, m2, n = 4, 7, 5
+#A1 = randn(m1, n)
+#A2 = randn(m2, n)
+#opA1 = MatrixOp(A1)
+#opA2 = MatrixOp(A2)
+#d1 = randn(m1)
+#d2 = randn(m2)
+#opV = VCAT(AffineAdd(opA1,d1), AffineAdd(opA2,d2))
+#x1 = randn(n)
+#y1 = opV*x1
+#y2 = (A1*x1+d1, A2*x1+d2)
+#@test all(norm.(y1 .- y2) .<= 1e-12)
+#y1 = remove_displacement(opV)*x1
+#y2 = (A1*x1, A2*x1)
+#@test all(norm.(y1 .- y2) .<= 1e-12)
+#
+##########################
+##### test BroadCast #####
+##########################
+#
+#m, n = 8, 4
+#dim_out = (m, 10)
+#A1 = randn(m, n)
+#opA1 = MatrixOp(A1)
+#opR = BroadCast(opA1, dim_out)
+#x1 = randn(n)
+#y1 = test_op(opR, x1, randn(dim_out), verb)
+#y2 = zeros(dim_out)
+#y2 .= A1*x1
+#@test norm(y1-y2) <= 1e-12
+#
+#m, n, l, k = 8, 4, 5, 7
+#dim_out = (m, n, l, k)
+#opA1 = Eye(m,n)
+#opR = BroadCast(opA1, dim_out)
+#x1 = randn(m,n)
+#y1 = test_op(opR, x1, randn(dim_out), verb)
+#y2 = zeros(dim_out)
+#y2 .= x1
+#@test norm(y1-y2) <= 1e-12
+#
+#@test_throws Exception BroadCast(opA1,(m,m))
+#
+#m, l = 1, 5
+#dim_out = (m, l)
+#opA1 = Eye(m)
+#opR = BroadCast(opA1, dim_out)
+#x1 = randn(m)
+#y1 = test_op(opR, x1, randn(dim_out), verb)
+#y2 = zeros(dim_out)
+#y2 .= x1
+#@test norm(y1-y2) <= 1e-12
+#
+##colum in - matrix out
+#m, l = 4, 5
+#dim_out = (m, l)
+#opA1 = Eye(1,l)
+#opR = BroadCast(opA1, dim_out)
+#x1 = randn(1,l)
+#y1 = test_op(opR, x1, randn(dim_out), verb)
+#y2 = zeros(dim_out)
+#y2 .= x1
+#@test norm(y1-y2) <= 1e-12
+#
+#op = HCAT(Eye(m,l),opR)
+#x1 = (randn(m,l),randn(1,l))
+#y1 = test_op(op, x1, randn(dim_out), verb)
+#y2 = x1[1].+x1[2]
+#@test norm(y1-y2) <= 1e-12
+#
+#m, n, l  = 2, 5, 8
+#dim_out = (m, n, l)
+#opA1 = Eye(m)
+#opR = BroadCast(opA1, dim_out)
+#x1 = randn(m)
+#y1 = test_op(opR, x1, randn(dim_out), verb)
+#y2 = zeros(dim_out)
+#y2 .= x1
+#@test norm(y1-y2) <= 1e-12
+#
+#m, n, l  = 1, 5, 8
+#dim_out = (m, n, l)
+#opA1 = Eye(m)
+#opR = BroadCast(opA1, dim_out)
+#x1 = randn(m)
+#y1 = test_op(opR, x1, randn(dim_out), verb)
+#y2 = zeros(dim_out)
+#y2 .= x1
+#@test norm(y1-y2) <= 1e-12
+#
+#m, n, l  = 1, 5, 8
+#dim_out = (m, n, l)
+#opA1 = Scale(2.4,Eye(m))
+#opR = BroadCast(opA1, dim_out)
+#x1 = randn(m)
+#y1 = test_op(opR, x1, randn(dim_out), verb)
+#y2 = zeros(dim_out)
+#y2 .= 2.4*x1
+#@test norm(y1-y2) <= 1e-12
+#
+#@test is_null(opR)             == is_null(opA1)            
+#@test is_eye(opR)              == false             
+#@test is_diagonal(opR)         == false 
+#@test is_AcA_diagonal(opR)     == false
+#@test is_AAc_diagonal(opR)     == false
+#@test is_orthogonal(opR)       == false
+#@test is_invertible(opR)       == false
+#@test is_full_row_rank(opR)    == false
+#@test is_full_column_rank(opR) == false
+#
+## test displacement
+#
+#m, n = 8, 4
+#dim_out = (m, 10)
+#A1 = randn(m, n)
+#d1 = randn(m)
+#opA1 = AffineAdd(MatrixOp(A1), d1)
+#opR = BroadCast(opA1, dim_out)
+#x1 = randn(n)
+#y1 = opR*x1
+#y2 = zeros(dim_out)
+#y2 .= A1*x1+d1
+#@test norm(y1-y2) <= 1e-12
+#x1 = randn(n)
+#y1 = remove_displacement(opR)*x1
+#y2 = zeros(dim_out)
+#y2 .= A1*x1
+#@test norm(y1-y2) <= 1e-12
+#
+############################
+###### test AffineAdd  #####
+############################
+#
+#n,m = 5,6
+#A = randn(n,m)
+#opA = MatrixOp(A)
+#d = randn(n)
+#T = AffineAdd(opA,d)
+#
+#println(T)
+#x1 = randn(m)
+#y1 = T*x1
+#@test norm(y1-(A*x1+d)) <1e-9
+#r = randn(n)
+#@test norm(T'*r-(A'*r)) <1e-9
+#@test displacement(T) == d
+#@test norm(remove_displacement(T)*x1-A*x1) <1e-9
+#
+## with sign
+#T = AffineAdd(opA,d,false)
+#@test sign(T) == -1
+#
+#println(T)
+#x1 = randn(m)
+#y1 = T*x1
+#@test norm(y1-(A*x1-d)) <1e-9
+#r = randn(n)
+#@test norm(T'*r-(A'*r)) <1e-9
+#@test displacement(T) == -d
+#@test norm(remove_displacement(T)*x1-A*x1) <1e-9
+#
+## with scalar
+#T = AffineAdd(opA,pi)
+#@test sign(T) == 1
+#
+#println(T)
+#x1 = randn(m)
+#y1 = T*x1
+#@test norm(y1-(A*x1.+pi)) <1e-9
+#r = randn(n)
+#@test norm(T'*r-(A'*r)) < 1e-9
+#@test displacement(T) .- pi < 1e-9
+#@test norm(remove_displacement(T)*x1-A*x1) <1e-9
+#
+#@test_throws DimensionMismatch AffineAdd(MatrixOp(randn(2,5)),randn(5))
+#@test_throws ErrorException AffineAdd(AbstractOperators.DFT(4),randn(4))
+#AffineAdd(AbstractOperators.DFT(4),pi)
+#@test_throws ErrorException AffineAdd(Eye(4),im*pi)
+#
+## with scalar and vector 
+#d = randn(n) 
+#T = AffineAdd(AffineAdd(opA,pi),d,false)
+#
+#println(T)
+#x1 = randn(m)
+#y1 = T*x1
+#@test norm(y1-(A*x1 .+ pi .- d)) <1e-9
+#r = randn(n)
+#@test norm(T'*r-(A'*r)) < 1e-9
+#@test norm(displacement(T) .- (pi .-d )) < 1e-9
+#
+#T2 = remove_displacement(T)
+#@test norm(T2*x1-(A*x1)) <1e-9
+#
+## permute AddAffine 
+#n,m = 5,6
+#A = randn(n,m)
+#d = randn(n)
+#opH = HCAT(Eye(n),MatrixOp(A))
+#x = (randn(n),randn(m))
+#opHT = AffineAdd(opH,d)
+#
+#@test norm(opHT*x-(x[1]+A*x[2].+d)) < 1e-12
+#p = [2;1]
+#@test norm(AbstractOperators.permute(opHT,p)*x[p]-(x[1]+A*x[2].+d)) < 1e-12
+#
+##############################
+######### test combin. #######
+##############################
+#
+### test Compose of HCAT
+#m1, m2, m3, m4 = 4, 7, 3, 2
+#A1 = randn(m3, m1)
+#A2 = randn(m3, m2)
+#A3 = randn(m4, m3)
+#opA1 = MatrixOp(A1)
+#opA2 = MatrixOp(A2)
+#opA3 = MatrixOp(A3)
+#opH = HCAT(opA1,opA2)
+#opC = Compose(opA3,opH)
+#x1, x2 = randn(m1), randn(m2)
+#y1 = test_op(opC, (x1,x2), randn(m4), verb)
+#
+#y2 = A3*(A1*x1+A2*x2)
+#
+#@test norm(y1-y2) < 1e-9
+#
+#opCp = AbstractOperators.permute(opC,[2,1])
+#y1 = test_op(opCp, (x2,x1), randn(m4), verb)
+#
+#@test norm(y1-y2) < 1e-9
+#
+### test HCAT of Compose of HCAT
+#m5 = 10
+#A4 = randn(m4,m5)
+#x3 = randn(m5)
+#opHC = HCAT(opC,MatrixOp(A4))
+#x = (x1,x2,x3)
+#y1 = test_op(opHC, x, randn(m4), verb)
+#
+#@test norm(y1-(y2+A4*x3)) < 1e-9
+#
+#p = randperm(ndoms(opHC,2))
+#opHP = AbstractOperators.permute(opHC,p)
+#
+#xp = x[p] 
+#
+#y1 = test_op(opHP, xp, randn(m4), verb)
+#
+#pp = randperm(ndoms(opHC,2))
+#opHPP = AbstractOperators.permute(opHC,pp)
+#xpp = x[pp] 
+#y1 = test_op(opHPP, xpp, randn(m4), verb)
+#
+#
+## test VCAT of HCAT's
+#m1, m2, n1 = 4, 7, 3
+#A1 = randn(n1, m1)
+#A2 = randn(n1, m2)
+#opA1 = MatrixOp(A1)
+#opA2 = MatrixOp(A2)
+#opH1 = HCAT(opA1,opA2)
+#
+#m1, m2, n2 = 4, 7, 5
+#A3 = randn(n2, m1)
+#A4 = randn(n2, m2)
+#opA3 = MatrixOp(A3)
+#opA4 = MatrixOp(A4)
+#opH2 = HCAT(opA3,opA4)
+#
+#opV = VCAT(opH1,opH2)
+#x1, x2 = randn(m1), randn(m2)
+#y1 = test_op(opV, (x1,x2), (randn(n1),randn(n2)), verb)
+#y2 = (A1*x1+A2*x2,A3*x1+A4*x2)
+#@test all(norm.(y1 .- y2) .<= 1e-12)
+#
+## test VCAT of HCAT's with complex num
+#m1, m2, n1 = 4, 7, 5
+#A1 = randn(n1, m1)+im*randn(n1, m1)
+#opA1 = MatrixOp(A1)
+#opA2 = AbstractOperators.DFT(n1)
+#opH1 = HCAT(opA1,opA2)
+#
+#m1, m2, n2 = 4, 7, 5
+#A3 = randn(n2, m1)+im*randn(n2,m1)
+#opA3 = MatrixOp(A3)
+#opA4 = AbstractOperators.DFT(n2)
+#opH2 = HCAT(opA3,opA4)
+#
+#opV = VCAT(opH1,opH2)
+#x1, x2 = randn(m1)+im*randn(m1), randn(n2)
+#y1 = test_op(opV, (x1,x2), (randn(n1)+im*randn(n1),randn(n2)+im*randn(n2)), verb)
+#y2 = (A1*x1+fft(x2),A3*x1+fft(x2))
+#@test all(norm.(y1 .- y2) .<= 1e-12)
+#
+## test HCAT of VCAT's
+#
+#n1, n2, m1, m2 = 3, 5, 4, 7
+#A = randn(m1, n1); opA = MatrixOp(A)
+#B = randn(m1, n2); opB = MatrixOp(B)
+#C = randn(m2, n1); opC = MatrixOp(C)
+#D = randn(m2, n2); opD = MatrixOp(D)
+#opV = HCAT(VCAT(opA, opC), VCAT(opB, opD))
+#x1 = randn(n1)
+#x2 = randn(n2)
+#y1 = test_op(opV, (x1, x2), (randn(m1), randn(m2)), verb)
+#y2 = (A*x1 + B*x2, C*x1 + D*x2)
+#
+#@test all(norm.(y1 .- y2) .<= 1e-12)
+#
+## test Sum of HCAT's
+#
+#m, n1, n2, n3 = 4, 7, 5, 3
+#A1 = randn(m, n1)
+#A2 = randn(m, n2)
+#A3 = randn(m, n3)
+#B1 = randn(m, n1)
+#B2 = randn(m, n2)
+#B3 = randn(m, n3)
+#opA1 = MatrixOp(A1)
+#opA2 = MatrixOp(A2)
+#opA3 = MatrixOp(A3)
+#opB1 = MatrixOp(B1)
+#opB2 = MatrixOp(B2)
+#opB3 = MatrixOp(B3)
+#opHA = HCAT(opA1, opA2, opA3)
+#opHB = HCAT(opB1, opB2, opB3)
+#opS = Sum(opHA, opHB)
+#x1 = randn(n1)
+#x2 = randn(n2)
+#x3 = randn(n3)
+#y1 = test_op(opS, (x1, x2, x3), randn(m), verb)
+#y2 = A1*x1 + B1*x1 + A2*x2 + B2*x2 + A3*x3 + B3*x3
+#
+#@test norm(y1-y2) <= 1e-12
+#
+#p = [3;2;1]
+#opSp = AbstractOperators.permute(opS,p)
+#y1 = test_op(opSp, (x1, x2, x3)[p], randn(m), verb)
+#
+## test Sum of VCAT's
+#
+#m1, m2, n = 4, 7, 5
+#A1 = randn(m1, n)
+#A2 = randn(m2, n)
+#B1 = randn(m1, n)
+#B2 = randn(m2, n)
+#C1 = randn(m1, n)
+#C2 = randn(m2, n)
+#opA1 = MatrixOp(A1)
+#opA2 = MatrixOp(A2)
+#opB1 = MatrixOp(B1)
+#opB2 = MatrixOp(B2)
+#opC1 = MatrixOp(C1)
+#opC2 = MatrixOp(C2)
+#opVA = VCAT(opA1, opA2)
+#opVB = VCAT(opB1, opB2)
+#opVC = VCAT(opC1, opC2)
+#opS = Sum(opVA, opVB, opVC)
+#x = randn(n)
+#y1 = test_op(opS, x, (randn(m1), randn(m2)), verb)
+#y2 = (A1*x + B1*x +C1*x, A2*x + B2*x + C2*x)
+#
+#@test all(norm.(y1 .- y2) .<= 1e-12)
+#
+## test Scale of DCAT
+#
+#m1, n1 = 4, 7
+#m2, n2 = 3, 5
+#A1 = randn(m1, n1)
+#A2 = randn(m2, n2)
+#opA1 = MatrixOp(A1)
+#opA2 = MatrixOp(A2)
+#opD = DCAT(opA1, opA2)
+#coeff = randn()
+#opS = Scale(coeff, opD)
+#x1 = randn(n1)
+#x2 = randn(n2)
+#y = test_op(opS, (x1, x2), (randn(m1), randn(m2)), verb)
+#z = (coeff*A1*x1, coeff*A2*x2)
+#
+#@test all(norm.(y .- z) .<= 1e-12)
+#
+## test Scale of VCAT
+#
+#m1, m2, n = 4, 3, 7
+#A1 = randn(m1, n)
+#A2 = randn(m2, n)
+#opA1 = MatrixOp(A1)
+#opA2 = MatrixOp(A2)
+#opV = VCAT(opA1, opA2)
+#coeff = randn()
+#opS = Scale(coeff, opV)
+#x = randn(n)
+#y = test_op(opS, x, (randn(m1), randn(m2)), verb)
+#z = (coeff*A1*x, coeff*A2*x)
+#
+#@test all(norm.(y .- z) .<= 1e-12)
+#
+## test Scale of HCAT
+#
+#m, n1, n2 = 4, 3, 7
+#A1 = randn(m, n1)
+#A2 = randn(m, n2)
+#opA1 = MatrixOp(A1)
+#opA2 = MatrixOp(A2)
+#opH = HCAT(opA1, opA2)
+#coeff = randn()
+#opS = Scale(coeff, opH)
+#x1 = randn(n1)
+#x2 = randn(n2)
+#y = test_op(opS, (x1, x2), randn(m), verb)
+#z = coeff*(A1*x1 + A2*x2)
+#
+#@test all(norm.(y .- z) .<= 1e-12)
+#
+## test DCAT of HCATs
+#
+#m1, m2, n1, n2, l1, l2, l3 = 2,3,4,5,6,7,8
+#A1 = randn(m1, n1)
+#A2 = randn(m1, n2)
+#B1 = randn(m2, n1)
+#B2 = randn(m2, n2)
+#B3 = randn(m2, n2)
+#opA1 = MatrixOp(A1)
+#opA2 = MatrixOp(A2)
+#opH1 = HCAT(opA1, opA2)
+#opB1 = MatrixOp(B1)
+#opB2 = MatrixOp(B2)
+#opB3 = MatrixOp(B3)
+#opH2 = HCAT(opB1, opB2, opB3)
+#
+#op = DCAT(opA1, opH2)
+#x =  randn.(size(op,2))
+#y0 = randn.(size(op,1))
+#y = test_op(op, x, y0, verb)
+#
+#op = DCAT(opH1, opH2)
+#x =  randn.(size(op,2))
+#y0 = randn.(size(op,1))
+#y = test_op(op, x, y0, verb)
+#
+#p = randperm(ndoms(op,2))
+#y2 = op[p]*x[p]
+#
+#@test AbstractOperators.blockvecnorm(y .- y2) <= 1e-8
+#
+## test Scale of Sum
+#
+#m,n = 5,7
+#A1 = randn(m,n)
+#A2 = randn(m,n)
+#opA1 = MatrixOp(A1)
+#opA2 = MatrixOp(A2)
+#opS = Sum(opA1,opA2)
+#coeff = pi
+#opSS = Scale(coeff,opS)
+#x1 = randn(n)
+#y1 = test_op(opSS, x1, randn(m), verb)
+#y2 = coeff*(A1*x1+A2*x1)
+#@test norm(y1-y2) <= 1e-12
+#
+## test Scale of Compose
+#
+#m1, m2, m3 = 4, 7, 3
+#A1 = randn(m2, m1)
+#A2 = randn(m3, m2)
+#opA1 = MatrixOp(A1)
+#opA2 = MatrixOp(A2)
+#
+#coeff = pi
+#opC = Compose(opA2,opA1)
+#opS = Scale(coeff,opC)
+#x = randn(m1)
+#y1 = test_op(opS, x, randn(m3), verb)
+#y2 = coeff*(A2*A1*x)
+#@test all(norm.(y1 .- y2) .<= 1e-12)
+#

--- a/test/test_linear_operators_calculus.jl
+++ b/test/test_linear_operators_calculus.jl
@@ -1,104 +1,104 @@
-#@printf("\nTesting linear operators calculus rules\n")
-#
-###########################
-###### test Compose #######
-###########################
-#m1, m2, m3 = 4, 7, 3
-#A1 = randn(m2, m1)
-#A2 = randn(m3, m2)
-#opA1 = MatrixOp(A1)
-#opA2 = MatrixOp(A2)
-#
-#opC = Compose(opA2,opA1)
-#x = randn(m1)
-#y1 = test_op(opC, x, randn(m3), verb)
-#y2 = A2*A1*x
-#@test all(norm.(y1 .- y2) .<= 1e-12)
-#
-## test Compose longer
-#m1, m2, m3, m4 = 4, 7, 3, 2
-#A1 = randn(m2, m1)
-#A2 = randn(m3, m2)
-#A3 = randn(m4, m3)
-#opA1 = MatrixOp(A1)
-#opA2 = MatrixOp(A2)
-#opA3 = MatrixOp(A3)
-#
-#opC1 = Compose(opA3,Compose(opA2,opA1))
-#opC2 = Compose(Compose(opA3,opA2),opA1)
-#x = randn(m1)
-#y1 = test_op(opC1, x, randn(m4), verb)
-#y2 = test_op(opC2, x, randn(m4), verb)
-#y3 = A3*A2*A1*x
-#@test all(norm.(y1 .- y2) .<= 1e-12)
-#@test all(norm.(y3 .- y2) .<= 1e-12)
-#
-##test Compose special cases
-#@test typeof(opA1*Eye(m1)) == typeof(opA1) 
-#@test typeof(Eye(m2)*opA1) == typeof(opA1) 
-#@test typeof(Eye(m2)*Eye(m2)) == typeof(Eye(m2)) 
-#
-#opS1 = Compose(opA2,opA1)
-#opS1c = Scale(pi,opS1)
-#@test typeof(opS1c.A[end]) <: Scale
-#
-##properties
-#@test is_sliced(opC)            == false
-#@test is_linear(opC1)           == true
-#@test is_null(opC1)             == false
-#@test is_eye(opC1)              == false
-#@test is_diagonal(opC1)         == false
-#@test is_AcA_diagonal(opC1)     == false
-#@test is_AAc_diagonal(opC1)     == false
-#@test is_orthogonal(opC1)       == false
-#@test is_invertible(opC1)       == false
-#@test is_full_row_rank(opC1)    == false
-#@test is_full_column_rank(opC1) == false
-#
-## properties special case
-#opC = DCT((5,))*GetIndex((10,), 1:5)
-#@test is_sliced(opC)           == true
-#@test is_AAc_diagonal(opC)     == true
-#@test diag_AAc(opC)            == 1.0
-#
-#d = randn(5)
-#opC = DiagOp(d)*GetIndex((10,), 1:5)
-#@test is_sliced(opC)           == true
-#@test is_diagonal(opC)         == true
-#@test diag(opC)                == d
-#
-## displacement test
-#m1, m2, m3, m4, m5 = 4, 7, 3, 2, 11
-#A1 = randn(m2, m1)
-#A2 = randn(m3, m2)
-#A3 = randn(m4, m3)
-#A4 = randn(m5, m4)
-#d1 = randn(m2)
-#d2 = pi
-#d3 = 0.0
-#d4 = randn(m5)
-#opA1 = AffineAdd(MatrixOp(A1),d1)  
-#opA2 = AffineAdd(MatrixOp(A2),d2)
-#opA3 = MatrixOp(A3)
-#opA4 = AffineAdd(MatrixOp(A4),d4,false) 
-#
-#opC  = Compose(Compose(Compose(opA4,opA3),opA2),opA1)
-#
-#x = randn(m1)
-#
-#@test norm( opC*x - (A4*(A3*( A2*( A1*x+d1 ) .+ d2 ) .+ d3)-d4) )  < 1e-9
-#@test norm( displacement(opC) - ( A4*(A3*(A2*d1 .+d2 ) .+ d3)-d4) ) < 1e-9
-#
-#opA4 = MatrixOp(A4)
-#opC  = AffineAdd(Compose(Compose(Compose(opA4,opA3),opA2),opA1),d4)
-#@test norm( opC*x - (A4*(A3*( A2*( A1*x+d1 ) .+ d2 ) .+ d3)+d4) )  < 1e-9
-#@test norm( displacement(opC) - ( A4*(A3*(A2*d1 .+ d2) .+ d3)+d4) ) < 1e-9
-#
-#@test norm( remove_displacement(opC)*x - (A4*(A3*( A2*( A1*x ) ) ) ) )  < 1e-9
-#
-#########################
-#### test DCAT    #######
-#########################
+@printf("\nTesting linear operators calculus rules\n")
+
+##########################
+##### test Compose #######
+##########################
+m1, m2, m3 = 4, 7, 3
+A1 = randn(m2, m1)
+A2 = randn(m3, m2)
+opA1 = MatrixOp(A1)
+opA2 = MatrixOp(A2)
+
+opC = Compose(opA2,opA1)
+x = randn(m1)
+y1 = test_op(opC, x, randn(m3), verb)
+y2 = A2*A1*x
+@test all(norm.(y1 .- y2) .<= 1e-12)
+
+# test Compose longer
+m1, m2, m3, m4 = 4, 7, 3, 2
+A1 = randn(m2, m1)
+A2 = randn(m3, m2)
+A3 = randn(m4, m3)
+opA1 = MatrixOp(A1)
+opA2 = MatrixOp(A2)
+opA3 = MatrixOp(A3)
+
+opC1 = Compose(opA3,Compose(opA2,opA1))
+opC2 = Compose(Compose(opA3,opA2),opA1)
+x = randn(m1)
+y1 = test_op(opC1, x, randn(m4), verb)
+y2 = test_op(opC2, x, randn(m4), verb)
+y3 = A3*A2*A1*x
+@test all(norm.(y1 .- y2) .<= 1e-12)
+@test all(norm.(y3 .- y2) .<= 1e-12)
+
+#test Compose special cases
+@test typeof(opA1*Eye(m1)) == typeof(opA1) 
+@test typeof(Eye(m2)*opA1) == typeof(opA1) 
+@test typeof(Eye(m2)*Eye(m2)) == typeof(Eye(m2)) 
+
+opS1 = Compose(opA2,opA1)
+opS1c = Scale(pi,opS1)
+@test typeof(opS1c.A[end]) <: Scale
+
+#properties
+@test is_sliced(opC)            == false
+@test is_linear(opC1)           == true
+@test is_null(opC1)             == false
+@test is_eye(opC1)              == false
+@test is_diagonal(opC1)         == false
+@test is_AcA_diagonal(opC1)     == false
+@test is_AAc_diagonal(opC1)     == false
+@test is_orthogonal(opC1)       == false
+@test is_invertible(opC1)       == false
+@test is_full_row_rank(opC1)    == false
+@test is_full_column_rank(opC1) == false
+
+# properties special case
+opC = DCT((5,))*GetIndex((10,), 1:5)
+@test is_sliced(opC)           == true
+@test is_AAc_diagonal(opC)     == true
+@test diag_AAc(opC)            == 1.0
+
+d = randn(5)
+opC = DiagOp(d)*GetIndex((10,), 1:5)
+@test is_sliced(opC)           == true
+@test is_diagonal(opC)         == true
+@test diag(opC)                == d
+
+# displacement test
+m1, m2, m3, m4, m5 = 4, 7, 3, 2, 11
+A1 = randn(m2, m1)
+A2 = randn(m3, m2)
+A3 = randn(m4, m3)
+A4 = randn(m5, m4)
+d1 = randn(m2)
+d2 = pi
+d3 = 0.0
+d4 = randn(m5)
+opA1 = AffineAdd(MatrixOp(A1),d1)  
+opA2 = AffineAdd(MatrixOp(A2),d2)
+opA3 = MatrixOp(A3)
+opA4 = AffineAdd(MatrixOp(A4),d4,false) 
+
+opC  = Compose(Compose(Compose(opA4,opA3),opA2),opA1)
+
+x = randn(m1)
+
+@test norm( opC*x - (A4*(A3*( A2*( A1*x+d1 ) .+ d2 ) .+ d3)-d4) )  < 1e-9
+@test norm( displacement(opC) - ( A4*(A3*(A2*d1 .+d2 ) .+ d3)-d4) ) < 1e-9
+
+opA4 = MatrixOp(A4)
+opC  = AffineAdd(Compose(Compose(Compose(opA4,opA3),opA2),opA1),d4)
+@test norm( opC*x - (A4*(A3*( A2*( A1*x+d1 ) .+ d2 ) .+ d3)+d4) )  < 1e-9
+@test norm( displacement(opC) - ( A4*(A3*(A2*d1 .+ d2) .+ d3)+d4) ) < 1e-9
+
+@test norm( remove_displacement(opC)*x - (A4*(A3*( A2*( A1*x ) ) ) ) )  < 1e-9
+
+########################
+### test DCAT    #######
+########################
 
 m1, n1, m2, n2 = 4, 7, 5, 2
 A1 = randn(m1, n1)
@@ -190,906 +190,905 @@ y1 = remove_displacement(opD)*ArrayPartition(x1,x2,x3)
 y2 = ArrayPartition(A1*x1, A2*x2, A3*x3)
 @test norm(y1 .- y2) .<= 1e-12
 
+#######################
+## test HCAT    #######
+#######################
+
+m, n1, n2 = 4, 7, 5
+A1 = randn(m, n1)
+A2 = randn(m, n2)
+opA1 = MatrixOp(A1)
+opA2 = MatrixOp(A2)
+opH = HCAT(opA1, opA2)
+x1 = randn(n1)
+x2 = randn(n2)
+y1 = test_op(opH, ArrayPartition(x1, x2), randn(m), verb)
+y2 = A1*x1 + A2*x2
+@test norm(y1-y2) <= 1e-12
+
+#permuatation 
+p = [2;1]
+opHp = opH[p]
+y1 = test_op(opHp, ArrayPartition(x2, x1), randn(m), verb)
+@test norm(y1-y2) <= 1e-12
+
+# test HCAT longer
+
+m, n1, n2, n3 = 4, 7, 5, 6
+A1 = randn(m, n1)
+A2 = randn(m, n2)
+A3 = randn(m, n3)
+opA1 = MatrixOp(A1)
+opA2 = MatrixOp(A2)
+opA3 = MatrixOp(A3)
+opH = HCAT(opA1, opA2, opA3)
+x1 = randn(n1)
+x2 = randn(n2)
+x3 = randn(n3)
+y1 = test_op(opH, ArrayPartition(x1, x2, x3), randn(m), verb)
+y2 = A1*x1 + A2*x2 + A3*x3
+@test norm(y1-y2) <= 1e-12
+
+# test HCAT of HCAT
+opHH = HCAT(opH, opA2, opA3)
+y1 = test_op(opHH, ArrayPartition(x1, x2, x3, x2, x3), randn(m), verb)
+y2 = A1*x1 + A2*x2 + A3*x3 + A2*x2 + A3*x3
+@test norm(y1-y2) <= 1e-12
+
+opHH = HCAT(opH, opH, opA3)
+x = ArrayPartition(x1, x2, x3, x1, x2, x3, x3)
+y1 = test_op(opHH, x, randn(m), verb)
+y2 = A1*x1 + A2*x2 + A3*x3 + A1*x1 + A2*x2 + A3*x3 + A3*x3
+@test norm(y1-y2) <= 1e-12
+
+opA3 = MatrixOp(randn(n1,n1))
+@test_throws Exception HCAT(opA1,opA2,opA3)
+opF = AbstractOperators.DFT(Complex{Float64},(m,))
+@test_throws Exception HCAT(opA1,opF,opA2)
+
+# test utilities
+
+# permutation
+p = randperm(ndoms(opHH,2))
+opHP = AbstractOperators.permute(opHH,p)
+
+xp = ArrayPartition(x.x[p]...) 
+
+y1 = test_op(opHP, xp, randn(m), verb)
+
+pp = randperm(ndoms(opHH,2))
+opHPP = AbstractOperators.permute(opHH,pp)
+xpp = ArrayPartition(x.x[pp]...) 
+y1 = test_op(opHPP, xpp, randn(m), verb)
+
+#properties
+m, n1, n2, n3 = 4, 7, 5, 6
+A1 = randn(m, n1)
+A2 = randn(m, n2)
+A3 = randn(m, n3)
+opA1 = MatrixOp(A1)
+opA2 = MatrixOp(A2)
+opA3 = MatrixOp(A3)
+op = HCAT(opA1, opA2, opA3)
+@test is_linear(op)           == true
+@test is_null(op)             == false
+@test is_eye(op)              == false
+@test is_diagonal(op)         == false
+@test is_AcA_diagonal(op)     == false
+@test is_AAc_diagonal(op)     == false
+@test is_orthogonal(op)       == false
+@test is_invertible(op)       == false
+@test is_full_row_rank(op)    == true
+@test is_full_column_rank(op) == false
+
+d = randn(n1).+im.*randn(n1)
+op = HCAT(DiagOp(d), AbstractOperators.DFT(Complex{Float64},n1))
+@test is_null(op)             == false
+@test is_eye(op)              == false
+@test is_diagonal(op)         == false
+@test is_AcA_diagonal(op)     == false
+@test is_AAc_diagonal(op)     == true
+@test is_orthogonal(op)       == false
+@test is_invertible(op)       == false
+@test is_full_row_rank(op)    == true
+@test is_full_column_rank(op) == false
+
+@test diag_AAc(op) == d .* conj(d) .+ n1
+
+y1 = randn(n1) .+ im .* randn(n1)
+@test norm(op*(op'*y1).-diag_AAc(op).*y1) <1e-12
+
+#test displacement
+
+m, n1, n2 = 4, 7, 5
+A1 = randn(m, n1)
+A2 = randn(m, n2)
+d1 = randn(m)
+d2 = randn(m)
+opA1 = AffineAdd(MatrixOp(A1), d1)
+opA2 = AffineAdd(MatrixOp(A2), d2)
+opH = HCAT(opA1, opA2)
+x1 = randn(n1)
+x2 = randn(n2)
+y1 = opH*ArrayPartition(x1,x2)
+y2 = A1*x1+d1 + A2*x2+d2
+@test norm(y1-y2) <= 1e-12
+y1 = remove_displacement(opH)*ArrayPartition(x1,x2)
+y2 = A1*x1 + A2*x2
+@test norm(y1-y2) <= 1e-12
+
 ########################
-### test HCAT    #######
+### test Reshape #######
 ########################
-#
-#m, n1, n2 = 4, 7, 5
-#A1 = randn(m, n1)
-#A2 = randn(m, n2)
-#opA1 = MatrixOp(A1)
-#opA2 = MatrixOp(A2)
-#opH = HCAT(opA1, opA2)
-#x1 = randn(n1)
-#x2 = randn(n2)
-#y1 = test_op(opH, (x1, x2), randn(m), verb)
-#y2 = A1*x1 + A2*x2
-#@test norm(y1-y2) <= 1e-12
-#
-##permuatation 
-#p = [2;1]
-#opHp = opH[p]
-#y1 = test_op(opHp, (x2, x1), randn(m), verb)
-#@test norm(y1-y2) <= 1e-12
-#
-## test HCAT longer
-#
-#m, n1, n2, n3 = 4, 7, 5, 6
-#A1 = randn(m, n1)
-#A2 = randn(m, n2)
-#A3 = randn(m, n3)
-#opA1 = MatrixOp(A1)
-#opA2 = MatrixOp(A2)
-#opA3 = MatrixOp(A3)
-#opH = HCAT(opA1, opA2, opA3)
-#x1 = randn(n1)
-#x2 = randn(n2)
-#x3 = randn(n3)
-#y1 = test_op(opH, (x1, x2, x3), randn(m), verb)
-#y2 = A1*x1 + A2*x2 + A3*x3
-#@test norm(y1-y2) <= 1e-12
-#
-## test HCAT of HCAT
-#opHH = HCAT(opH, opA2, opA3)
-#y1 = test_op(opHH, (x1, x2, x3, x2, x3), randn(m), verb)
-#y2 = A1*x1 + A2*x2 + A3*x3 + A2*x2 + A3*x3
-#@test norm(y1-y2) <= 1e-12
-#
-#opHH = HCAT(opH, opH, opA3)
-#x = (x1, x2, x3, x1, x2, x3, x3)
-#y1 = test_op(opHH, x, randn(m), verb)
-#y2 = A1*x1 + A2*x2 + A3*x3 + A1*x1 + A2*x2 + A3*x3 + A3*x3
-#@test norm(y1-y2) <= 1e-12
-#
-#opA3 = MatrixOp(randn(n1,n1))
-#@test_throws Exception HCAT(opA1,opA2,opA3)
-#opF = AbstractOperators.DFT(Complex{Float64},(m,))
-#@test_throws Exception HCAT(opA1,opF,opA2)
-#
-## test utilities
-#
-## permutation
-#p = randperm(ndoms(opHH,2))
-#opHP = AbstractOperators.permute(opHH,p)
-#
-#xp = x[p] 
-#
-#y1 = test_op(opHP, xp, randn(m), verb)
-#
-#pp = randperm(ndoms(opHH,2))
-#opHPP = AbstractOperators.permute(opHH,pp)
-#xpp = x[pp] 
-#y1 = test_op(opHPP, xpp, randn(m), verb)
-#
-##properties
-#m, n1, n2, n3 = 4, 7, 5, 6
-#A1 = randn(m, n1)
-#A2 = randn(m, n2)
-#A3 = randn(m, n3)
-#opA1 = MatrixOp(A1)
-#opA2 = MatrixOp(A2)
-#opA3 = MatrixOp(A3)
-#op = HCAT(opA1, opA2, opA3)
-#@test is_linear(op)           == true
-#@test is_null(op)             == false
-#@test is_eye(op)              == false
-#@test is_diagonal(op)         == false
-#@test is_AcA_diagonal(op)     == false
-#@test is_AAc_diagonal(op)     == false
-#@test is_orthogonal(op)       == false
-#@test is_invertible(op)       == false
-#@test is_full_row_rank(op)    == true
-#@test is_full_column_rank(op) == false
-#
-#d = randn(n1).+im.*randn(n1)
-#op = HCAT(DiagOp(d), AbstractOperators.DFT(Complex{Float64},n1))
-#@test is_null(op)             == false
-#@test is_eye(op)              == false
-#@test is_diagonal(op)         == false
-#@test is_AcA_diagonal(op)     == false
-#@test is_AAc_diagonal(op)     == true
-#@test is_orthogonal(op)       == false
-#@test is_invertible(op)       == false
-#@test is_full_row_rank(op)    == true
-#@test is_full_column_rank(op) == false
-#
-#@test diag_AAc(op) == d .* conj(d) .+ n1
-#
-#y1 = randn(n1) .+ im .* randn(n1)
-#@test norm(op*(op'*y1).-diag_AAc(op).*y1) <1e-12
-#
-##test displacement
-#
-#m, n1, n2 = 4, 7, 5
-#A1 = randn(m, n1)
-#A2 = randn(m, n2)
-#d1 = randn(m)
-#d2 = randn(m)
-#opA1 = AffineAdd(MatrixOp(A1), d1)
-#opA2 = AffineAdd(MatrixOp(A2), d2)
-#opH = HCAT(opA1, opA2)
-#x1 = randn(n1)
-#x2 = randn(n2)
-#y1 = opH*(x1,x2)
-#y2 = A1*x1+d1 + A2*x2+d2
-#@test norm(y1-y2) <= 1e-12
-#y1 = remove_displacement(opH)*(x1,x2)
-#y2 = A1*x1 + A2*x2
-#@test norm(y1-y2) <= 1e-12
-#
-#########################
-#### test Reshape #######
-#########################
-#
-#m, n = 8, 4
-#dim_out = (2, 2, 2)
-#A1 = randn(m, n)
-#opA1 = MatrixOp(A1)
-#opR = Reshape(opA1, dim_out)
-#opR = Reshape(opA1, dim_out...)
-#x1 = randn(n)
-#y1 = test_op(opR, x1, randn(dim_out), verb)
-#y2 = reshape(A1*x1, dim_out)
-#@test norm(y1-y2) <= 1e-12
-#
-#@test_throws Exception Reshape(opA1,(2,2,1))
-#
-#@test is_null(opR)             == is_null(opA1)            
-#@test is_eye(opR)              == is_eye(opA1)             
-#@test is_diagonal(opR)         == is_diagonal(opA1)        
-#@test is_AcA_diagonal(opR)     == is_AcA_diagonal(opA1)    
-#@test is_AAc_diagonal(opR)     == is_AAc_diagonal(opA1)    
-#@test is_orthogonal(opR)       == is_orthogonal(opA1)      
-#@test is_invertible(opR)       == is_invertible(opA1)      
-#@test is_full_row_rank(opR)    == is_full_row_rank(opA1)   
-#@test is_full_column_rank(opR) == is_full_column_rank(opA1)
-#
+
+m, n = 8, 4
+dim_out = (2, 2, 2)
+A1 = randn(m, n)
+opA1 = MatrixOp(A1)
+opR = Reshape(opA1, dim_out)
+opR = Reshape(opA1, dim_out...)
+x1 = randn(n)
+y1 = test_op(opR, x1, randn(dim_out), verb)
+y2 = reshape(A1*x1, dim_out)
+@test norm(y1-y2) <= 1e-12
+
+@test_throws Exception Reshape(opA1,(2,2,1))
+
+@test is_null(opR)             == is_null(opA1)            
+@test is_eye(opR)              == is_eye(opA1)             
+@test is_diagonal(opR)         == is_diagonal(opA1)        
+@test is_AcA_diagonal(opR)     == is_AcA_diagonal(opA1)    
+@test is_AAc_diagonal(opR)     == is_AAc_diagonal(opA1)    
+@test is_orthogonal(opR)       == is_orthogonal(opA1)      
+@test is_invertible(opR)       == is_invertible(opA1)      
+@test is_full_row_rank(opR)    == is_full_row_rank(opA1)   
+@test is_full_column_rank(opR) == is_full_column_rank(opA1)
+
+# testing displacement
+m, n = 8, 4
+dim_out = (2, 2, 2)
+A1 = randn(m, n)
+d1 = randn(m)
+opA1 = AffineAdd(MatrixOp(A1),d1)
+opR = Reshape(opA1, dim_out)
+x1 = randn(n)
+y1 = opR*x1
+y2 = reshape(A1*x1+d1, dim_out)
+@test norm(y1-y2) <= 1e-12
+y1 = remove_displacement(opR)*x1
+y2 = reshape(A1*x1, dim_out)
+@test norm(y1-y2) <= 1e-12
+
+#######################
+## test Scale   #######
+#######################
+
+m, n = 8, 4
+coeff = pi
+A1 = randn(m, n)
+opA1 = MatrixOp(A1)
+opS = Scale(coeff, opA1)
+x1 = randn(n)
+y1 = test_op(opS, x1, randn(m), verb)
+y2 = coeff*A1*x1
+@test norm(y1-y2) <= 1e-12
+
+coeff2 = 3
+opS2 = Scale(coeff2, opS)
+y1 = test_op(opS2, x1, randn(m), verb)
+y2 = coeff2*coeff*A1*x1
+@test norm(y1-y2) <= 1e-12
+
+opF = AbstractOperators.DFT(m,n)
+opS = Scale(coeff, opF)
+x1 = randn(m,n)
+y1 = test_op(opS, x1, fft(randn(m,n)), verb)
+y2 = coeff*(fft(x1))
+@test norm(y1-y2) <= 1e-12
+
+opS = Scale(coeff, opA1)
+@test is_null(opS)             == is_null(opA1)            
+@test is_eye(opS)              == is_eye(opA1)             
+@test is_diagonal(opS)         == is_diagonal(opA1)        
+@test is_AcA_diagonal(opS)     == is_AcA_diagonal(opA1)    
+@test is_AAc_diagonal(opS)     == is_AAc_diagonal(opA1)    
+@test is_orthogonal(opS)       == is_orthogonal(opA1)      
+@test is_invertible(opS)       == is_invertible(opA1)      
+@test is_full_row_rank(opS)    == is_full_row_rank(opA1)   
+@test is_full_column_rank(opS) == is_full_column_rank(opA1)
+
+op = Scale(-4.0,AbstractOperators.DFT(10))
+@test is_AAc_diagonal(op)     == true
+@test diag_AAc(op) == 16*10
+
+op = Scale(-4.0,ZeroPad((10,), 20))
+@test is_AcA_diagonal(op)     == true
+@test diag_AcA(op) == 16
+
+# special case, Scale of DiagOp gets a DiagOp
+d = randn(10)
+op = Scale(3,DiagOp(d))
+@test typeof(op) <: DiagOp
+@test norm(diag(op) - 3 .*d) < 1e-12
+
+# Scale with imaginary coeff gives error
+m, n = 8, 4
+coeff = im
+A1 = randn(m, n)
+opA1 = MatrixOp(A1)
+@test_throws ErrorException Scale(coeff, opA1)
+
 ## testing displacement
-#m, n = 8, 4
-#dim_out = (2, 2, 2)
-#A1 = randn(m, n)
-#d1 = randn(m)
-#opA1 = AffineAdd(MatrixOp(A1),d1)
-#opR = Reshape(opA1, dim_out)
-#x1 = randn(n)
-#y1 = opR*x1
-#y2 = reshape(A1*x1+d1, dim_out)
-#@test norm(y1-y2) <= 1e-12
-#y1 = remove_displacement(opR)*x1
-#y2 = reshape(A1*x1, dim_out)
-#@test norm(y1-y2) <= 1e-12
-#
+m, n = 8, 4
+coeff = pi
+A1 = randn(m, n)
+d1 = randn(m)
+opA1 = AffineAdd(MatrixOp(A1),d1)
+opS = Scale(coeff, opA1)
+x1 = randn(n)
+y1 = opS*x1
+y2 = coeff*(A1*x1+d1)
+@test norm(y1-y2) <= 1e-12
+y1 = remove_displacement(opS)*x1
+y2 = coeff*(A1*x1)
+@test norm(y1-y2) <= 1e-12
+
 ########################
-### test Scale   #######
+### test Sum     #######
 ########################
-#
-#m, n = 8, 4
-#coeff = pi
-#A1 = randn(m, n)
-#opA1 = MatrixOp(A1)
-#opS = Scale(coeff, opA1)
-#x1 = randn(n)
-#y1 = test_op(opS, x1, randn(m), verb)
-#y2 = coeff*A1*x1
-#@test norm(y1-y2) <= 1e-12
-#
-#coeff2 = 3
-#opS2 = Scale(coeff2, opS)
-#y1 = test_op(opS2, x1, randn(m), verb)
-#y2 = coeff2*coeff*A1*x1
-#@test norm(y1-y2) <= 1e-12
-#
-#opF = AbstractOperators.DFT(m,n)
-#opS = Scale(coeff, opF)
-#x1 = randn(m,n)
-#y1 = test_op(opS, x1, fft(randn(m,n)), verb)
-#y2 = coeff*(fft(x1))
-#@test norm(y1-y2) <= 1e-12
-#
-#opS = Scale(coeff, opA1)
-#@test is_null(opS)             == is_null(opA1)            
-#@test is_eye(opS)              == is_eye(opA1)             
-#@test is_diagonal(opS)         == is_diagonal(opA1)        
-#@test is_AcA_diagonal(opS)     == is_AcA_diagonal(opA1)    
-#@test is_AAc_diagonal(opS)     == is_AAc_diagonal(opA1)    
-#@test is_orthogonal(opS)       == is_orthogonal(opA1)      
-#@test is_invertible(opS)       == is_invertible(opA1)      
-#@test is_full_row_rank(opS)    == is_full_row_rank(opA1)   
-#@test is_full_column_rank(opS) == is_full_column_rank(opA1)
-#
-#op = Scale(-4.0,AbstractOperators.DFT(10))
-#@test is_AAc_diagonal(op)     == true
-#@test diag_AAc(op) == 16*10
-#
-#op = Scale(-4.0,ZeroPad((10,), 20))
-#@test is_AcA_diagonal(op)     == true
-#@test diag_AcA(op) == 16
-#
-## special case, Scale of DiagOp gets a DiagOp
-#d = randn(10)
-#op = Scale(3,DiagOp(d))
-#@test typeof(op) <: DiagOp
-#@test norm(diag(op) - 3 .*d) < 1e-12
-#
-## Scale with imaginary coeff gives error
-#m, n = 8, 4
-#coeff = im
-#A1 = randn(m, n)
-#opA1 = MatrixOp(A1)
-#@test_throws ErrorException Scale(coeff, opA1)
-#
-### testing displacement
-#m, n = 8, 4
-#coeff = pi
-#A1 = randn(m, n)
-#d1 = randn(m)
-#opA1 = AffineAdd(MatrixOp(A1),d1)
-#opS = Scale(coeff, opA1)
-#x1 = randn(n)
-#y1 = opS*x1
-#y2 = coeff*(A1*x1+d1)
-#@test norm(y1-y2) <= 1e-12
-#y1 = remove_displacement(opS)*x1
-#y2 = coeff*(A1*x1)
-#@test norm(y1-y2) <= 1e-12
-#
-##########################
-##### test Sum     #######
-##########################
-#
-#m,n = 5,7
-#A1 = randn(m,n)
-#A2 = randn(m,n)
-#opA1 = MatrixOp(A1)
-#opA2 = MatrixOp(A2)
-#opS = Sum(opA1,opA2)
-#x1 = randn(n)
-#y1 = test_op(opS, x1, randn(m), verb)
-#y2 = A1*x1+A2*x1
-#@test norm(y1-y2) <= 1e-12
-#
-##test Sum longer
-#m,n = 5,7
-#A1 = randn(m,n)
-#A2 = randn(m,n)
-#A3 = randn(m,n)
-#opA1 = MatrixOp(A1)
-#opA2 = MatrixOp(A2)
-#opA3 = MatrixOp(A3)
-#opS = Sum(opA1,opA2,opA3)
-#x1 = randn(n)
-#y1 = test_op(opS, x1, randn(m), verb)
-#y2 = A1*x1+A2*x1+A3*x1
-#@test norm(y1-y2) <= 1e-12
-#
-#opA3 = MatrixOp(randn(m,m))
-#@test_throws Exception Sum(opA1,opA3)
-#opF = AbstractOperators.DFT(Float64,(m,))
-#@test_throws Exception Sum(opF,opA3)
-#
-#@test is_null(opS)             == false
-#@test is_eye(opS)              == false 
-#@test is_diagonal(opS)         == false
-#@test is_AcA_diagonal(opS)     == false
-#@test is_AAc_diagonal(opS)     == false
-#@test is_orthogonal(opS)       == false
-#@test is_invertible(opS)       == false
-#@test is_full_row_rank(opS)    == true
-#@test is_full_column_rank(opS) == false
-#
-#d = randn(10)
-#op = Sum(Scale(-3.1,Eye(10)),DiagOp(d))
-#@test is_diagonal(op)         == true
-#@test norm(   diag(op) - (d .-3.1)  )<1e-12
-#
-##test displacement of sum
-#m,n = 5,7
-#A1 = randn(m,n)
-#A2 = randn(m,n)
-#A3 = randn(m,n)
-#d1 = randn(m)
-#d2 = pi
-#d3 = randn(m)
-#opA1 = AffineAdd(MatrixOp(A1), d1) 
-#opA2 = AffineAdd(MatrixOp(A2), d2)
-#opA3 = AffineAdd(MatrixOp(A3), d3) 
-#opS = Sum(opA1,opA2,opA3)
-#x1 = randn(n)
-#y2 = A1*x1+A2*x1+A3*x1+d1.+d2+d3
-#@test norm(opS*x1-y2) <= 1e-12
-#@test norm(displacement(opS) - (d1.+d2+d3)) <= 1e-12
-#y2 = A1*x1+A2*x1+A3*x1
-#@test norm(remove_displacement(opS)*x1-y2) <= 1e-12
-#
-####################################
-####### test AdjointOperator #######
-####################################
-#
-#m,n = 5,7
-#A1 = randn(m,n)
-#opA1 = MatrixOp(A1)
-#opA1t = MatrixOp(A1')
-#opT = AdjointOperator(opA1)
-#x1 = randn(m)
-#y1 = test_op(opT, x1, randn(n), verb)
-#y2 = A1'*x1
-#@test norm(y1-y2) <= 1e-12
-#
-#@test is_null(opT)             == is_null(opA1t)            
-#@test is_eye(opT)              == is_eye(opA1t)             
-#@test is_diagonal(opT)         == is_diagonal(opA1t)        
-#@test is_AcA_diagonal(opT)     == is_AcA_diagonal(opA1t)    
-#@test is_AAc_diagonal(opT)     == is_AAc_diagonal(opA1t)    
-#@test is_orthogonal(opT)       == is_orthogonal(opA1t)      
-#@test is_invertible(opT)       == is_invertible(opA1t)      
-#@test is_full_row_rank(opT)    == is_full_row_rank(opA1t)   
-#@test is_full_column_rank(opT) == is_full_column_rank(opA1t)
-#
-#d = randn(3)
-#op = AdjointOperator(DiagOp(d))
-#@test is_diagonal(op) == true
-#@test diag(op) == d
-#
-#op = AdjointOperator(ZeroPad((10,),5))
-#@test is_AcA_diagonal(op) == false
-#@test is_AAc_diagonal(op) == true
-#@test diag_AAc(op) == 1
-#
-##############################
-######### test VCAT    #######
-##############################
-#
-#m1, m2, n = 4, 7, 5
-#A1 = randn(m1, n)
-#A2 = randn(m2, n)
-#opA1 = MatrixOp(A1)
-#opA2 = MatrixOp(A2)
-#opV = VCAT(opA1, opA2)
-#x1 = randn(n)
-#y1 = test_op(opV, x1, (randn(m1), randn(m2)), verb)
-#y2 = (A1*x1, A2*x1)
-#@test all(norm.(y1 .- y2) .<= 1e-12)
-#
-#m1, n = 4, 5
-#A1 = randn(m1, n)+im*randn(m1, n)
-#opA1 = MatrixOp(A1)
-#opA2 = AbstractOperators.DFT(n)'
-#opV = VCAT(opA1, opA2)
-#x1 = randn(n)+im*randn(n)
-#y1 = test_op(opV, x1, (randn(m1)+im*randn(m1), randn(n)), verb)
-#y2 = (A1*x1, opA2*x1)
-#@test all(norm.(y1 .- y2) .<= 1e-12)
-#
-##test VCAT longer
-#m1, m2, m3, n = 4, 7, 3, 5
-#A1 = randn(m1, n)
-#A2 = randn(m2, n)
-#A3 = randn(m3, n)
-#opA1 = MatrixOp(A1)
-#opA2 = MatrixOp(A2)
-#opA3 = MatrixOp(A3)
-#opV = VCAT(opA1, opA2, opA3)
-#x1 = randn(n)
-#y1 = test_op(opV, x1, (randn(m1), randn(m2), randn(m3)), verb)
-#y2 = (A1*x1, A2*x1, A3*x1)
-#@test all(norm.(y1 .- y2) .<= 1e-12)
-#
-##test VCAT of VCAT
-#opVV = VCAT(opV,opA3)
-#y1 = test_op(opVV, x1, (randn(m1), randn(m2), randn(m3), randn(m3)), verb)
-#y2 = (A1*x1, A2*x1, A3*x1, A3*x1)
-#@test all(norm.(y1 .- y2) .<= 1e-12)
-#
-#opVV = VCAT(opA1,opV,opA3)
-#y1 = test_op(opVV, x1, (randn(m1), randn(m1), randn(m2), randn(m3), randn(m3)), verb)
-#y2 = (A1*x1, A1*x1, A2*x1, A3*x1, A3*x1)
-#@test all(norm.(y1 .- y2) .<= 1e-12)
-#
-#opA3 = MatrixOp(randn(m1,m1))
-#@test_throws Exception VCAT(opA1,opA2,opA3)
-#opF = AbstractOperators.DFT(Complex{Float64},(n,))
-#@test_throws Exception VCAT(opA1,opF,opA2)
-#
-####properties
-#m1, m2, m3, n = 4, 7, 3, 5
-#A1 = randn(m1, n)
-#A2 = randn(m2, n)
-#A3 = randn(m3, n)
-#opA1 = MatrixOp(A1)
-#opA2 = MatrixOp(A2)
-#opA3 = MatrixOp(A3)
-#op = VCAT(opA1, opA2, opA3)
-#@test is_linear(op)           == true
-#@test is_null(op)             == false
-#@test is_eye(op)              == false
-#@test is_diagonal(op)         == false
-#@test is_AcA_diagonal(op)     == false
-#@test is_AAc_diagonal(op)     == false
-#@test is_orthogonal(op)       == false
-#@test is_invertible(op)       == false
-#@test is_full_row_rank(op)    == false
-#@test is_full_column_rank(op) == true
-#
-#op = VCAT(AbstractOperators.DFT(Complex{Float64},10), Eye(Complex{Float64},10) )
-#@test is_AcA_diagonal(op)     == true
-#@test diag_AcA(op) == 11
-#
-###test displacement
-#m1, m2, n = 4, 7, 5
-#A1 = randn(m1, n)
-#A2 = randn(m2, n)
-#opA1 = MatrixOp(A1)
-#opA2 = MatrixOp(A2)
-#d1 = randn(m1)
-#d2 = randn(m2)
-#opV = VCAT(AffineAdd(opA1,d1), AffineAdd(opA2,d2))
-#x1 = randn(n)
-#y1 = opV*x1
-#y2 = (A1*x1+d1, A2*x1+d2)
-#@test all(norm.(y1 .- y2) .<= 1e-12)
-#y1 = remove_displacement(opV)*x1
-#y2 = (A1*x1, A2*x1)
-#@test all(norm.(y1 .- y2) .<= 1e-12)
-#
-##########################
-##### test BroadCast #####
-##########################
-#
-#m, n = 8, 4
-#dim_out = (m, 10)
-#A1 = randn(m, n)
-#opA1 = MatrixOp(A1)
-#opR = BroadCast(opA1, dim_out)
-#x1 = randn(n)
-#y1 = test_op(opR, x1, randn(dim_out), verb)
-#y2 = zeros(dim_out)
-#y2 .= A1*x1
-#@test norm(y1-y2) <= 1e-12
-#
-#m, n, l, k = 8, 4, 5, 7
-#dim_out = (m, n, l, k)
-#opA1 = Eye(m,n)
-#opR = BroadCast(opA1, dim_out)
-#x1 = randn(m,n)
-#y1 = test_op(opR, x1, randn(dim_out), verb)
-#y2 = zeros(dim_out)
-#y2 .= x1
-#@test norm(y1-y2) <= 1e-12
-#
-#@test_throws Exception BroadCast(opA1,(m,m))
-#
-#m, l = 1, 5
-#dim_out = (m, l)
-#opA1 = Eye(m)
-#opR = BroadCast(opA1, dim_out)
-#x1 = randn(m)
-#y1 = test_op(opR, x1, randn(dim_out), verb)
-#y2 = zeros(dim_out)
-#y2 .= x1
-#@test norm(y1-y2) <= 1e-12
-#
-##colum in - matrix out
-#m, l = 4, 5
-#dim_out = (m, l)
-#opA1 = Eye(1,l)
-#opR = BroadCast(opA1, dim_out)
-#x1 = randn(1,l)
-#y1 = test_op(opR, x1, randn(dim_out), verb)
-#y2 = zeros(dim_out)
-#y2 .= x1
-#@test norm(y1-y2) <= 1e-12
-#
-#op = HCAT(Eye(m,l),opR)
-#x1 = (randn(m,l),randn(1,l))
-#y1 = test_op(op, x1, randn(dim_out), verb)
-#y2 = x1[1].+x1[2]
-#@test norm(y1-y2) <= 1e-12
-#
-#m, n, l  = 2, 5, 8
-#dim_out = (m, n, l)
-#opA1 = Eye(m)
-#opR = BroadCast(opA1, dim_out)
-#x1 = randn(m)
-#y1 = test_op(opR, x1, randn(dim_out), verb)
-#y2 = zeros(dim_out)
-#y2 .= x1
-#@test norm(y1-y2) <= 1e-12
-#
-#m, n, l  = 1, 5, 8
-#dim_out = (m, n, l)
-#opA1 = Eye(m)
-#opR = BroadCast(opA1, dim_out)
-#x1 = randn(m)
-#y1 = test_op(opR, x1, randn(dim_out), verb)
-#y2 = zeros(dim_out)
-#y2 .= x1
-#@test norm(y1-y2) <= 1e-12
-#
-#m, n, l  = 1, 5, 8
-#dim_out = (m, n, l)
-#opA1 = Scale(2.4,Eye(m))
-#opR = BroadCast(opA1, dim_out)
-#x1 = randn(m)
-#y1 = test_op(opR, x1, randn(dim_out), verb)
-#y2 = zeros(dim_out)
-#y2 .= 2.4*x1
-#@test norm(y1-y2) <= 1e-12
-#
-#@test is_null(opR)             == is_null(opA1)            
-#@test is_eye(opR)              == false             
-#@test is_diagonal(opR)         == false 
-#@test is_AcA_diagonal(opR)     == false
-#@test is_AAc_diagonal(opR)     == false
-#@test is_orthogonal(opR)       == false
-#@test is_invertible(opR)       == false
-#@test is_full_row_rank(opR)    == false
-#@test is_full_column_rank(opR) == false
-#
-## test displacement
-#
-#m, n = 8, 4
-#dim_out = (m, 10)
-#A1 = randn(m, n)
-#d1 = randn(m)
-#opA1 = AffineAdd(MatrixOp(A1), d1)
-#opR = BroadCast(opA1, dim_out)
-#x1 = randn(n)
-#y1 = opR*x1
-#y2 = zeros(dim_out)
-#y2 .= A1*x1+d1
-#@test norm(y1-y2) <= 1e-12
-#x1 = randn(n)
-#y1 = remove_displacement(opR)*x1
-#y2 = zeros(dim_out)
-#y2 .= A1*x1
-#@test norm(y1-y2) <= 1e-12
-#
+
+m,n = 5,7
+A1 = randn(m,n)
+A2 = randn(m,n)
+opA1 = MatrixOp(A1)
+opA2 = MatrixOp(A2)
+opS = Sum(opA1,opA2)
+x1 = randn(n)
+y1 = test_op(opS, x1, randn(m), verb)
+y2 = A1*x1+A2*x1
+@test norm(y1-y2) <= 1e-12
+
+#test Sum longer
+m,n = 5,7
+A1 = randn(m,n)
+A2 = randn(m,n)
+A3 = randn(m,n)
+opA1 = MatrixOp(A1)
+opA2 = MatrixOp(A2)
+opA3 = MatrixOp(A3)
+opS = Sum(opA1,opA2,opA3)
+x1 = randn(n)
+y1 = test_op(opS, x1, randn(m), verb)
+y2 = A1*x1+A2*x1+A3*x1
+@test norm(y1-y2) <= 1e-12
+
+opA3 = MatrixOp(randn(m,m))
+@test_throws Exception Sum(opA1,opA3)
+opF = AbstractOperators.DFT(Float64,(m,))
+@test_throws Exception Sum(opF,opA3)
+
+@test is_null(opS)             == false
+@test is_eye(opS)              == false 
+@test is_diagonal(opS)         == false
+@test is_AcA_diagonal(opS)     == false
+@test is_AAc_diagonal(opS)     == false
+@test is_orthogonal(opS)       == false
+@test is_invertible(opS)       == false
+@test is_full_row_rank(opS)    == true
+@test is_full_column_rank(opS) == false
+
+d = randn(10)
+op = Sum(Scale(-3.1,Eye(10)),DiagOp(d))
+@test is_diagonal(op)         == true
+@test norm(   diag(op) - (d .-3.1)  )<1e-12
+
+#test displacement of sum
+m,n = 5,7
+A1 = randn(m,n)
+A2 = randn(m,n)
+A3 = randn(m,n)
+d1 = randn(m)
+d2 = pi
+d3 = randn(m)
+opA1 = AffineAdd(MatrixOp(A1), d1) 
+opA2 = AffineAdd(MatrixOp(A2), d2)
+opA3 = AffineAdd(MatrixOp(A3), d3) 
+opS = Sum(opA1,opA2,opA3)
+x1 = randn(n)
+y2 = A1*x1+A2*x1+A3*x1+d1.+d2+d3
+@test norm(opS*x1-y2) <= 1e-12
+@test norm(displacement(opS) - (d1.+d2+d3)) <= 1e-12
+y2 = A1*x1+A2*x1+A3*x1
+@test norm(remove_displacement(opS)*x1-y2) <= 1e-12
+
+###################################
+###### test AdjointOperator #######
+###################################
+
+m,n = 5,7
+A1 = randn(m,n)
+opA1 = MatrixOp(A1)
+opA1t = MatrixOp(A1')
+opT = AdjointOperator(opA1)
+x1 = randn(m)
+y1 = test_op(opT, x1, randn(n), verb)
+y2 = A1'*x1
+@test norm(y1-y2) <= 1e-12
+
+@test is_null(opT)             == is_null(opA1t)            
+@test is_eye(opT)              == is_eye(opA1t)             
+@test is_diagonal(opT)         == is_diagonal(opA1t)        
+@test is_AcA_diagonal(opT)     == is_AcA_diagonal(opA1t)    
+@test is_AAc_diagonal(opT)     == is_AAc_diagonal(opA1t)    
+@test is_orthogonal(opT)       == is_orthogonal(opA1t)      
+@test is_invertible(opT)       == is_invertible(opA1t)      
+@test is_full_row_rank(opT)    == is_full_row_rank(opA1t)   
+@test is_full_column_rank(opT) == is_full_column_rank(opA1t)
+
+d = randn(3)
+op = AdjointOperator(DiagOp(d))
+@test is_diagonal(op) == true
+@test diag(op) == d
+
+op = AdjointOperator(ZeroPad((10,),5))
+@test is_AcA_diagonal(op) == false
+@test is_AAc_diagonal(op) == true
+@test diag_AAc(op) == 1
+
+#############################
+######## test VCAT    #######
+#############################
+
+m1, m2, n = 4, 7, 5
+A1 = randn(m1, n)
+A2 = randn(m2, n)
+opA1 = MatrixOp(A1)
+opA2 = MatrixOp(A2)
+opV = VCAT(opA1, opA2)
+x1 = randn(n)
+y1 = test_op(opV, x1, ArrayPartition(randn(m1), randn(m2)), verb)
+y2 = ArrayPartition(A1*x1, A2*x1)
+@test norm(y1 - y2) .<= 1e-12
+
+m1, n = 4, 5
+A1 = randn(m1, n)+im*randn(m1, n)
+opA1 = MatrixOp(A1)
+opA2 = AbstractOperators.DFT(n)'
+opV = VCAT(opA1, opA2)
+x1 = randn(n)+im*randn(n)
+y1 = test_op(opV, x1, ArrayPartition(randn(m1)+im*randn(m1), randn(n)), verb)
+y2 = ArrayPartition(A1*x1, opA2*x1)
+@test norm(y1 - y2) .<= 1e-12
+
+#test VCAT longer
+m1, m2, m3, n = 4, 7, 3, 5
+A1 = randn(m1, n)
+A2 = randn(m2, n)
+A3 = randn(m3, n)
+opA1 = MatrixOp(A1)
+opA2 = MatrixOp(A2)
+opA3 = MatrixOp(A3)
+opV = VCAT(opA1, opA2, opA3)
+x1 = randn(n)
+y1 = test_op(opV, x1, ArrayPartition(randn(m1), randn(m2), randn(m3)), verb)
+y2 = ArrayPartition(A1*x1, A2*x1, A3*x1)
+@test norm(y1 - y2) .<= 1e-12
+
+#test VCAT of VCAT
+opVV = VCAT(opV,opA3)
+y1 = test_op(opVV, x1, ArrayPartition(randn(m1), randn(m2), randn(m3), randn(m3)), verb)
+y2 = ArrayPartition(A1*x1, A2*x1, A3*x1, A3*x1)
+@test norm(y1 .- y2) <= 1e-12
+
+opVV = VCAT(opA1,opV,opA3)
+y1 = test_op(opVV, x1, ArrayPartition(randn(m1), randn(m1), randn(m2), randn(m3), randn(m3)), verb)
+y2 = ArrayPartition(A1*x1, A1*x1, A2*x1, A3*x1, A3*x1)
+@test norm(y1 - y2) <= 1e-12
+
+opA3 = MatrixOp(randn(m1,m1))
+@test_throws Exception VCAT(opA1,opA2,opA3)
+opF = AbstractOperators.DFT(Complex{Float64},(n,))
+@test_throws Exception VCAT(opA1,opF,opA2)
+
+###properties
+m1, m2, m3, n = 4, 7, 3, 5
+A1 = randn(m1, n)
+A2 = randn(m2, n)
+A3 = randn(m3, n)
+opA1 = MatrixOp(A1)
+opA2 = MatrixOp(A2)
+opA3 = MatrixOp(A3)
+op = VCAT(opA1, opA2, opA3)
+@test is_linear(op)           == true
+@test is_null(op)             == false
+@test is_eye(op)              == false
+@test is_diagonal(op)         == false
+@test is_AcA_diagonal(op)     == false
+@test is_AAc_diagonal(op)     == false
+@test is_orthogonal(op)       == false
+@test is_invertible(op)       == false
+@test is_full_row_rank(op)    == false
+@test is_full_column_rank(op) == true
+
+op = VCAT(AbstractOperators.DFT(Complex{Float64},10), Eye(Complex{Float64},10) )
+@test is_AcA_diagonal(op)     == true
+@test diag_AcA(op) == 11
+
+##test displacement
+m1, m2, n = 4, 7, 5
+A1 = randn(m1, n)
+A2 = randn(m2, n)
+opA1 = MatrixOp(A1)
+opA2 = MatrixOp(A2)
+d1 = randn(m1)
+d2 = randn(m2)
+opV = VCAT(AffineAdd(opA1,d1), AffineAdd(opA2,d2))
+x1 = randn(n)
+y1 = opV*x1
+y2 = ArrayPartition(A1*x1+d1, A2*x1+d2)
+@test norm(y1 - y2) <= 1e-12
+y1 = remove_displacement(opV)*x1
+y2 = ArrayPartition(A1*x1, A2*x1)
+@test norm(y1 - y2) <= 1e-12
+
+#########################
+#### test BroadCast #####
+#########################
+
+m, n = 8, 4
+dim_out = (m, 10)
+A1 = randn(m, n)
+opA1 = MatrixOp(A1)
+opR = BroadCast(opA1, dim_out)
+x1 = randn(n)
+y1 = test_op(opR, x1, randn(dim_out), verb)
+y2 = zeros(dim_out)
+y2 .= A1*x1
+@test norm(y1-y2) <= 1e-12
+
+m, n, l, k = 8, 4, 5, 7
+dim_out = (m, n, l, k)
+opA1 = Eye(m,n)
+opR = BroadCast(opA1, dim_out)
+x1 = randn(m,n)
+y1 = test_op(opR, x1, randn(dim_out), verb)
+y2 = zeros(dim_out)
+y2 .= x1
+@test norm(y1-y2) <= 1e-12
+
+@test_throws Exception BroadCast(opA1,(m,m))
+
+m, l = 1, 5
+dim_out = (m, l)
+opA1 = Eye(m)
+opR = BroadCast(opA1, dim_out)
+x1 = randn(m)
+y1 = test_op(opR, x1, randn(dim_out), verb)
+y2 = zeros(dim_out)
+y2 .= x1
+@test norm(y1-y2) <= 1e-12
+
+#colum in - matrix out
+m, l = 4, 5
+dim_out = (m, l)
+opA1 = Eye(1,l)
+opR = BroadCast(opA1, dim_out)
+x1 = randn(1,l)
+y1 = test_op(opR, x1, randn(dim_out), verb)
+y2 = zeros(dim_out)
+y2 .= x1
+@test norm(y1-y2) <= 1e-12
+
+op = HCAT(Eye(m,l),opR)
+x1 = ArrayPartition(randn(m,l),randn(1,l))
+y1 = test_op(op, x1, randn(dim_out), verb)
+y2 = x1.x[1].+x1.x[2]
+@test norm(y1-y2) <= 1e-12
+
+m, n, l  = 2, 5, 8
+dim_out = (m, n, l)
+opA1 = Eye(m)
+opR = BroadCast(opA1, dim_out)
+x1 = randn(m)
+y1 = test_op(opR, x1, randn(dim_out), verb)
+y2 = zeros(dim_out)
+y2 .= x1
+@test norm(y1-y2) <= 1e-12
+
+m, n, l  = 1, 5, 8
+dim_out = (m, n, l)
+opA1 = Eye(m)
+opR = BroadCast(opA1, dim_out)
+x1 = randn(m)
+y1 = test_op(opR, x1, randn(dim_out), verb)
+y2 = zeros(dim_out)
+y2 .= x1
+@test norm(y1-y2) <= 1e-12
+
+m, n, l  = 1, 5, 8
+dim_out = (m, n, l)
+opA1 = Scale(2.4,Eye(m))
+opR = BroadCast(opA1, dim_out)
+x1 = randn(m)
+y1 = test_op(opR, x1, randn(dim_out), verb)
+y2 = zeros(dim_out)
+y2 .= 2.4*x1
+@test norm(y1-y2) <= 1e-12
+
+@test is_null(opR)             == is_null(opA1)            
+@test is_eye(opR)              == false             
+@test is_diagonal(opR)         == false 
+@test is_AcA_diagonal(opR)     == false
+@test is_AAc_diagonal(opR)     == false
+@test is_orthogonal(opR)       == false
+@test is_invertible(opR)       == false
+@test is_full_row_rank(opR)    == false
+@test is_full_column_rank(opR) == false
+
+# test displacement
+
+m, n = 8, 4
+dim_out = (m, 10)
+A1 = randn(m, n)
+d1 = randn(m)
+opA1 = AffineAdd(MatrixOp(A1), d1)
+opR = BroadCast(opA1, dim_out)
+x1 = randn(n)
+y1 = opR*x1
+y2 = zeros(dim_out)
+y2 .= A1*x1+d1
+@test norm(y1-y2) <= 1e-12
+x1 = randn(n)
+y1 = remove_displacement(opR)*x1
+y2 = zeros(dim_out)
+y2 .= A1*x1
+@test norm(y1-y2) <= 1e-12
+
+###########################
+##### test AffineAdd  #####
+###########################
+
+n,m = 5,6
+A = randn(n,m)
+opA = MatrixOp(A)
+d = randn(n)
+T = AffineAdd(opA,d)
+
+println(T)
+x1 = randn(m)
+y1 = T*x1
+@test norm(y1-(A*x1+d)) <1e-9
+r = randn(n)
+@test norm(T'*r-(A'*r)) <1e-9
+@test displacement(T) == d
+@test norm(remove_displacement(T)*x1-A*x1) <1e-9
+
+# with sign
+T = AffineAdd(opA,d,false)
+@test sign(T) == -1
+
+println(T)
+x1 = randn(m)
+y1 = T*x1
+@test norm(y1-(A*x1-d)) <1e-9
+r = randn(n)
+@test norm(T'*r-(A'*r)) <1e-9
+@test displacement(T) == -d
+@test norm(remove_displacement(T)*x1-A*x1) <1e-9
+
+# with scalar
+T = AffineAdd(opA,pi)
+@test sign(T) == 1
+
+println(T)
+x1 = randn(m)
+y1 = T*x1
+@test norm(y1-(A*x1.+pi)) <1e-9
+r = randn(n)
+@test norm(T'*r-(A'*r)) < 1e-9
+@test displacement(T) .- pi < 1e-9
+@test norm(remove_displacement(T)*x1-A*x1) <1e-9
+
+@test_throws DimensionMismatch AffineAdd(MatrixOp(randn(2,5)),randn(5))
+@test_throws ErrorException AffineAdd(AbstractOperators.DFT(4),randn(4))
+AffineAdd(AbstractOperators.DFT(4),pi)
+@test_throws ErrorException AffineAdd(Eye(4),im*pi)
+
+# with scalar and vector 
+d = randn(n) 
+T = AffineAdd(AffineAdd(opA,pi),d,false)
+
+println(T)
+x1 = randn(m)
+y1 = T*x1
+@test norm(y1-(A*x1 .+ pi .- d)) <1e-9
+r = randn(n)
+@test norm(T'*r-(A'*r)) < 1e-9
+@test norm(displacement(T) .- (pi .-d )) < 1e-9
+
+T2 = remove_displacement(T)
+@test norm(T2*x1-(A*x1)) <1e-9
+
+# permute AddAffine 
+n,m = 5,6
+A = randn(n,m)
+d = randn(n)
+opH = HCAT(Eye(n),MatrixOp(A))
+x = ArrayPartition(randn(n),randn(m))
+opHT = AffineAdd(opH,d)
+
+@test norm(opHT*x-(x.x[1]+A*x.x[2].+d)) < 1e-12
+p = [2;1]
+@test norm(AbstractOperators.permute(opHT,p)*ArrayPartition(x.x[p]...)-(x.x[1]+A*x.x[2].+d)) < 1e-12
+
 ############################
-###### test AffineAdd  #####
+####### test combin. #######
 ############################
-#
-#n,m = 5,6
-#A = randn(n,m)
-#opA = MatrixOp(A)
-#d = randn(n)
-#T = AffineAdd(opA,d)
-#
-#println(T)
-#x1 = randn(m)
-#y1 = T*x1
-#@test norm(y1-(A*x1+d)) <1e-9
-#r = randn(n)
-#@test norm(T'*r-(A'*r)) <1e-9
-#@test displacement(T) == d
-#@test norm(remove_displacement(T)*x1-A*x1) <1e-9
-#
-## with sign
-#T = AffineAdd(opA,d,false)
-#@test sign(T) == -1
-#
-#println(T)
-#x1 = randn(m)
-#y1 = T*x1
-#@test norm(y1-(A*x1-d)) <1e-9
-#r = randn(n)
-#@test norm(T'*r-(A'*r)) <1e-9
-#@test displacement(T) == -d
-#@test norm(remove_displacement(T)*x1-A*x1) <1e-9
-#
-## with scalar
-#T = AffineAdd(opA,pi)
-#@test sign(T) == 1
-#
-#println(T)
-#x1 = randn(m)
-#y1 = T*x1
-#@test norm(y1-(A*x1.+pi)) <1e-9
-#r = randn(n)
-#@test norm(T'*r-(A'*r)) < 1e-9
-#@test displacement(T) .- pi < 1e-9
-#@test norm(remove_displacement(T)*x1-A*x1) <1e-9
-#
-#@test_throws DimensionMismatch AffineAdd(MatrixOp(randn(2,5)),randn(5))
-#@test_throws ErrorException AffineAdd(AbstractOperators.DFT(4),randn(4))
-#AffineAdd(AbstractOperators.DFT(4),pi)
-#@test_throws ErrorException AffineAdd(Eye(4),im*pi)
-#
-## with scalar and vector 
-#d = randn(n) 
-#T = AffineAdd(AffineAdd(opA,pi),d,false)
-#
-#println(T)
-#x1 = randn(m)
-#y1 = T*x1
-#@test norm(y1-(A*x1 .+ pi .- d)) <1e-9
-#r = randn(n)
-#@test norm(T'*r-(A'*r)) < 1e-9
-#@test norm(displacement(T) .- (pi .-d )) < 1e-9
-#
-#T2 = remove_displacement(T)
-#@test norm(T2*x1-(A*x1)) <1e-9
-#
-## permute AddAffine 
-#n,m = 5,6
-#A = randn(n,m)
-#d = randn(n)
-#opH = HCAT(Eye(n),MatrixOp(A))
-#x = (randn(n),randn(m))
-#opHT = AffineAdd(opH,d)
-#
-#@test norm(opHT*x-(x[1]+A*x[2].+d)) < 1e-12
-#p = [2;1]
-#@test norm(AbstractOperators.permute(opHT,p)*x[p]-(x[1]+A*x[2].+d)) < 1e-12
-#
-##############################
-######### test combin. #######
-##############################
-#
-### test Compose of HCAT
-#m1, m2, m3, m4 = 4, 7, 3, 2
-#A1 = randn(m3, m1)
-#A2 = randn(m3, m2)
-#A3 = randn(m4, m3)
-#opA1 = MatrixOp(A1)
-#opA2 = MatrixOp(A2)
-#opA3 = MatrixOp(A3)
-#opH = HCAT(opA1,opA2)
-#opC = Compose(opA3,opH)
-#x1, x2 = randn(m1), randn(m2)
-#y1 = test_op(opC, (x1,x2), randn(m4), verb)
-#
-#y2 = A3*(A1*x1+A2*x2)
-#
-#@test norm(y1-y2) < 1e-9
-#
-#opCp = AbstractOperators.permute(opC,[2,1])
-#y1 = test_op(opCp, (x2,x1), randn(m4), verb)
-#
-#@test norm(y1-y2) < 1e-9
-#
-### test HCAT of Compose of HCAT
-#m5 = 10
-#A4 = randn(m4,m5)
-#x3 = randn(m5)
-#opHC = HCAT(opC,MatrixOp(A4))
-#x = (x1,x2,x3)
-#y1 = test_op(opHC, x, randn(m4), verb)
-#
-#@test norm(y1-(y2+A4*x3)) < 1e-9
-#
-#p = randperm(ndoms(opHC,2))
-#opHP = AbstractOperators.permute(opHC,p)
-#
-#xp = x[p] 
-#
-#y1 = test_op(opHP, xp, randn(m4), verb)
-#
-#pp = randperm(ndoms(opHC,2))
-#opHPP = AbstractOperators.permute(opHC,pp)
-#xpp = x[pp] 
-#y1 = test_op(opHPP, xpp, randn(m4), verb)
-#
-#
-## test VCAT of HCAT's
-#m1, m2, n1 = 4, 7, 3
-#A1 = randn(n1, m1)
-#A2 = randn(n1, m2)
-#opA1 = MatrixOp(A1)
-#opA2 = MatrixOp(A2)
-#opH1 = HCAT(opA1,opA2)
-#
-#m1, m2, n2 = 4, 7, 5
-#A3 = randn(n2, m1)
-#A4 = randn(n2, m2)
-#opA3 = MatrixOp(A3)
-#opA4 = MatrixOp(A4)
-#opH2 = HCAT(opA3,opA4)
-#
-#opV = VCAT(opH1,opH2)
-#x1, x2 = randn(m1), randn(m2)
-#y1 = test_op(opV, (x1,x2), (randn(n1),randn(n2)), verb)
-#y2 = (A1*x1+A2*x2,A3*x1+A4*x2)
-#@test all(norm.(y1 .- y2) .<= 1e-12)
-#
-## test VCAT of HCAT's with complex num
-#m1, m2, n1 = 4, 7, 5
-#A1 = randn(n1, m1)+im*randn(n1, m1)
-#opA1 = MatrixOp(A1)
-#opA2 = AbstractOperators.DFT(n1)
-#opH1 = HCAT(opA1,opA2)
-#
-#m1, m2, n2 = 4, 7, 5
-#A3 = randn(n2, m1)+im*randn(n2,m1)
-#opA3 = MatrixOp(A3)
-#opA4 = AbstractOperators.DFT(n2)
-#opH2 = HCAT(opA3,opA4)
-#
-#opV = VCAT(opH1,opH2)
-#x1, x2 = randn(m1)+im*randn(m1), randn(n2)
-#y1 = test_op(opV, (x1,x2), (randn(n1)+im*randn(n1),randn(n2)+im*randn(n2)), verb)
-#y2 = (A1*x1+fft(x2),A3*x1+fft(x2))
-#@test all(norm.(y1 .- y2) .<= 1e-12)
-#
-## test HCAT of VCAT's
-#
-#n1, n2, m1, m2 = 3, 5, 4, 7
-#A = randn(m1, n1); opA = MatrixOp(A)
-#B = randn(m1, n2); opB = MatrixOp(B)
-#C = randn(m2, n1); opC = MatrixOp(C)
-#D = randn(m2, n2); opD = MatrixOp(D)
-#opV = HCAT(VCAT(opA, opC), VCAT(opB, opD))
-#x1 = randn(n1)
-#x2 = randn(n2)
-#y1 = test_op(opV, (x1, x2), (randn(m1), randn(m2)), verb)
-#y2 = (A*x1 + B*x2, C*x1 + D*x2)
-#
-#@test all(norm.(y1 .- y2) .<= 1e-12)
-#
-## test Sum of HCAT's
-#
-#m, n1, n2, n3 = 4, 7, 5, 3
-#A1 = randn(m, n1)
-#A2 = randn(m, n2)
-#A3 = randn(m, n3)
-#B1 = randn(m, n1)
-#B2 = randn(m, n2)
-#B3 = randn(m, n3)
-#opA1 = MatrixOp(A1)
-#opA2 = MatrixOp(A2)
-#opA3 = MatrixOp(A3)
-#opB1 = MatrixOp(B1)
-#opB2 = MatrixOp(B2)
-#opB3 = MatrixOp(B3)
-#opHA = HCAT(opA1, opA2, opA3)
-#opHB = HCAT(opB1, opB2, opB3)
-#opS = Sum(opHA, opHB)
-#x1 = randn(n1)
-#x2 = randn(n2)
-#x3 = randn(n3)
-#y1 = test_op(opS, (x1, x2, x3), randn(m), verb)
-#y2 = A1*x1 + B1*x1 + A2*x2 + B2*x2 + A3*x3 + B3*x3
-#
-#@test norm(y1-y2) <= 1e-12
-#
-#p = [3;2;1]
-#opSp = AbstractOperators.permute(opS,p)
-#y1 = test_op(opSp, (x1, x2, x3)[p], randn(m), verb)
-#
-## test Sum of VCAT's
-#
-#m1, m2, n = 4, 7, 5
-#A1 = randn(m1, n)
-#A2 = randn(m2, n)
-#B1 = randn(m1, n)
-#B2 = randn(m2, n)
-#C1 = randn(m1, n)
-#C2 = randn(m2, n)
-#opA1 = MatrixOp(A1)
-#opA2 = MatrixOp(A2)
-#opB1 = MatrixOp(B1)
-#opB2 = MatrixOp(B2)
-#opC1 = MatrixOp(C1)
-#opC2 = MatrixOp(C2)
-#opVA = VCAT(opA1, opA2)
-#opVB = VCAT(opB1, opB2)
-#opVC = VCAT(opC1, opC2)
-#opS = Sum(opVA, opVB, opVC)
-#x = randn(n)
-#y1 = test_op(opS, x, (randn(m1), randn(m2)), verb)
-#y2 = (A1*x + B1*x +C1*x, A2*x + B2*x + C2*x)
-#
-#@test all(norm.(y1 .- y2) .<= 1e-12)
-#
-## test Scale of DCAT
-#
-#m1, n1 = 4, 7
-#m2, n2 = 3, 5
-#A1 = randn(m1, n1)
-#A2 = randn(m2, n2)
-#opA1 = MatrixOp(A1)
-#opA2 = MatrixOp(A2)
-#opD = DCAT(opA1, opA2)
-#coeff = randn()
-#opS = Scale(coeff, opD)
-#x1 = randn(n1)
-#x2 = randn(n2)
-#y = test_op(opS, (x1, x2), (randn(m1), randn(m2)), verb)
-#z = (coeff*A1*x1, coeff*A2*x2)
-#
-#@test all(norm.(y .- z) .<= 1e-12)
-#
-## test Scale of VCAT
-#
-#m1, m2, n = 4, 3, 7
-#A1 = randn(m1, n)
-#A2 = randn(m2, n)
-#opA1 = MatrixOp(A1)
-#opA2 = MatrixOp(A2)
-#opV = VCAT(opA1, opA2)
-#coeff = randn()
-#opS = Scale(coeff, opV)
-#x = randn(n)
-#y = test_op(opS, x, (randn(m1), randn(m2)), verb)
-#z = (coeff*A1*x, coeff*A2*x)
-#
-#@test all(norm.(y .- z) .<= 1e-12)
-#
-## test Scale of HCAT
-#
-#m, n1, n2 = 4, 3, 7
-#A1 = randn(m, n1)
-#A2 = randn(m, n2)
-#opA1 = MatrixOp(A1)
-#opA2 = MatrixOp(A2)
-#opH = HCAT(opA1, opA2)
-#coeff = randn()
-#opS = Scale(coeff, opH)
-#x1 = randn(n1)
-#x2 = randn(n2)
-#y = test_op(opS, (x1, x2), randn(m), verb)
-#z = coeff*(A1*x1 + A2*x2)
-#
-#@test all(norm.(y .- z) .<= 1e-12)
-#
-## test DCAT of HCATs
-#
-#m1, m2, n1, n2, l1, l2, l3 = 2,3,4,5,6,7,8
-#A1 = randn(m1, n1)
-#A2 = randn(m1, n2)
-#B1 = randn(m2, n1)
-#B2 = randn(m2, n2)
-#B3 = randn(m2, n2)
-#opA1 = MatrixOp(A1)
-#opA2 = MatrixOp(A2)
-#opH1 = HCAT(opA1, opA2)
-#opB1 = MatrixOp(B1)
-#opB2 = MatrixOp(B2)
-#opB3 = MatrixOp(B3)
-#opH2 = HCAT(opB1, opB2, opB3)
-#
-#op = DCAT(opA1, opH2)
-#x =  randn.(size(op,2))
-#y0 = randn.(size(op,1))
-#y = test_op(op, x, y0, verb)
-#
-#op = DCAT(opH1, opH2)
-#x =  randn.(size(op,2))
-#y0 = randn.(size(op,1))
-#y = test_op(op, x, y0, verb)
-#
-#p = randperm(ndoms(op,2))
-#y2 = op[p]*x[p]
-#
-#@test AbstractOperators.blockvecnorm(y .- y2) <= 1e-8
-#
-## test Scale of Sum
-#
-#m,n = 5,7
-#A1 = randn(m,n)
-#A2 = randn(m,n)
-#opA1 = MatrixOp(A1)
-#opA2 = MatrixOp(A2)
-#opS = Sum(opA1,opA2)
-#coeff = pi
-#opSS = Scale(coeff,opS)
-#x1 = randn(n)
-#y1 = test_op(opSS, x1, randn(m), verb)
-#y2 = coeff*(A1*x1+A2*x1)
-#@test norm(y1-y2) <= 1e-12
-#
-## test Scale of Compose
-#
-#m1, m2, m3 = 4, 7, 3
-#A1 = randn(m2, m1)
-#A2 = randn(m3, m2)
-#opA1 = MatrixOp(A1)
-#opA2 = MatrixOp(A2)
-#
-#coeff = pi
-#opC = Compose(opA2,opA1)
-#opS = Scale(coeff,opC)
-#x = randn(m1)
-#y1 = test_op(opS, x, randn(m3), verb)
-#y2 = coeff*(A2*A1*x)
-#@test all(norm.(y1 .- y2) .<= 1e-12)
-#
+
+## test Compose of HCAT
+m1, m2, m3, m4 = 4, 7, 3, 2
+A1 = randn(m3, m1)
+A2 = randn(m3, m2)
+A3 = randn(m4, m3)
+opA1 = MatrixOp(A1)
+opA2 = MatrixOp(A2)
+opA3 = MatrixOp(A3)
+opH = HCAT(opA1,opA2)
+opC = Compose(opA3,opH)
+x1, x2 = randn(m1), randn(m2)
+y1 = test_op(opC, ArrayPartition(x1,x2), randn(m4), verb)
+
+y2 = A3*(A1*x1+A2*x2)
+
+@test norm(y1-y2) < 1e-9
+
+opCp = AbstractOperators.permute(opC,[2,1])
+y1 = test_op(opCp, ArrayPartition(x2,x1), randn(m4), verb)
+
+@test norm(y1-y2) < 1e-9
+
+## test HCAT of Compose of HCAT
+m5 = 10
+A4 = randn(m4,m5)
+x3 = randn(m5)
+opHC = HCAT(opC,MatrixOp(A4))
+x = ArrayPartition(x1,x2,x3)
+y1 = test_op(opHC, x, randn(m4), verb)
+
+@test norm(y1-(y2+A4*x3)) < 1e-9
+
+p = randperm(ndoms(opHC,2))
+opHP = AbstractOperators.permute(opHC,p)
+
+xp = ArrayPartition(x.x[p]...) 
+
+y1 = test_op(opHP, xp, randn(m4), verb)
+
+pp = randperm(ndoms(opHC,2))
+opHPP = AbstractOperators.permute(opHC,pp)
+xpp = ArrayPartition(x.x[pp]...) 
+y1 = test_op(opHPP, xpp, randn(m4), verb)
+
+# test VCAT of HCAT's
+m1, m2, n1 = 4, 7, 3
+A1 = randn(n1, m1)
+A2 = randn(n1, m2)
+opA1 = MatrixOp(A1)
+opA2 = MatrixOp(A2)
+opH1 = HCAT(opA1,opA2)
+
+m1, m2, n2 = 4, 7, 5
+A3 = randn(n2, m1)
+A4 = randn(n2, m2)
+opA3 = MatrixOp(A3)
+opA4 = MatrixOp(A4)
+opH2 = HCAT(opA3,opA4)
+
+opV = VCAT(opH1,opH2)
+x1, x2 = randn(m1), randn(m2)
+y1 = test_op(opV, ArrayPartition(x1,x2), ArrayPartition(randn(n1),randn(n2)), verb)
+y2 = ArrayPartition(A1*x1+A2*x2,A3*x1+A4*x2)
+@test norm(y1 - y2) <= 1e-12
+
+# test VCAT of HCAT's with complex num
+m1, m2, n1 = 4, 7, 5
+A1 = randn(n1, m1)+im*randn(n1, m1)
+opA1 = MatrixOp(A1)
+opA2 = AbstractOperators.DFT(n1)
+opH1 = HCAT(opA1,opA2)
+
+m1, m2, n2 = 4, 7, 5
+A3 = randn(n2, m1)+im*randn(n2,m1)
+opA3 = MatrixOp(A3)
+opA4 = AbstractOperators.DFT(n2)
+opH2 = HCAT(opA3,opA4)
+
+opV = VCAT(opH1,opH2)
+x1, x2 = randn(m1)+im*randn(m1), randn(n2)
+y1 = test_op(opV, ArrayPartition(x1,x2), ArrayPartition(randn(n1)+im*randn(n1),randn(n2)+im*randn(n2)), verb)
+y2 = ArrayPartition(A1*x1+fft(x2),A3*x1+fft(x2))
+@test norm(y1 - y2) <= 1e-12
+
+# test HCAT of VCAT's
+
+n1, n2, m1, m2 = 3, 5, 4, 7
+A = randn(m1, n1); opA = MatrixOp(A)
+B = randn(m1, n2); opB = MatrixOp(B)
+C = randn(m2, n1); opC = MatrixOp(C)
+D = randn(m2, n2); opD = MatrixOp(D)
+opV = HCAT(VCAT(opA, opC), VCAT(opB, opD))
+x1 = randn(n1)
+x2 = randn(n2)
+y1 = test_op(opV, ArrayPartition(x1, x2), ArrayPartition(randn(m1), randn(m2)), verb)
+y2 = ArrayPartition(A*x1 + B*x2, C*x1 + D*x2)
+
+@test norm(y1 - y2) <= 1e-12
+
+# test Sum of HCAT's
+
+m, n1, n2, n3 = 4, 7, 5, 3
+A1 = randn(m, n1)
+A2 = randn(m, n2)
+A3 = randn(m, n3)
+B1 = randn(m, n1)
+B2 = randn(m, n2)
+B3 = randn(m, n3)
+opA1 = MatrixOp(A1)
+opA2 = MatrixOp(A2)
+opA3 = MatrixOp(A3)
+opB1 = MatrixOp(B1)
+opB2 = MatrixOp(B2)
+opB3 = MatrixOp(B3)
+opHA = HCAT(opA1, opA2, opA3)
+opHB = HCAT(opB1, opB2, opB3)
+opS = Sum(opHA, opHB)
+x1 = randn(n1)
+x2 = randn(n2)
+x3 = randn(n3)
+y1 = test_op(opS, ArrayPartition(x1, x2, x3), randn(m), verb)
+y2 = A1*x1 + B1*x1 + A2*x2 + B2*x2 + A3*x3 + B3*x3
+
+@test norm(y1-y2) <= 1e-12
+
+p = [3;2;1]
+opSp = AbstractOperators.permute(opS,p)
+y1 = test_op(opSp, ArrayPartition(((x1, x2, x3)[p])...), randn(m), verb)
+
+# test Sum of VCAT's
+
+m1, m2, n = 4, 7, 5
+A1 = randn(m1, n)
+A2 = randn(m2, n)
+B1 = randn(m1, n)
+B2 = randn(m2, n)
+C1 = randn(m1, n)
+C2 = randn(m2, n)
+opA1 = MatrixOp(A1)
+opA2 = MatrixOp(A2)
+opB1 = MatrixOp(B1)
+opB2 = MatrixOp(B2)
+opC1 = MatrixOp(C1)
+opC2 = MatrixOp(C2)
+opVA = VCAT(opA1, opA2)
+opVB = VCAT(opB1, opB2)
+opVC = VCAT(opC1, opC2)
+opS = Sum(opVA, opVB, opVC)
+x = randn(n)
+y1 = test_op(opS, x, ArrayPartition(randn(m1), randn(m2)), verb)
+y2 = ArrayPartition(A1*x + B1*x +C1*x, A2*x + B2*x + C2*x)
+
+@test norm(y1 - y2) .<= 1e-12
+
+# test Scale of DCAT
+
+m1, n1 = 4, 7
+m2, n2 = 3, 5
+A1 = randn(m1, n1)
+A2 = randn(m2, n2)
+opA1 = MatrixOp(A1)
+opA2 = MatrixOp(A2)
+opD = DCAT(opA1, opA2)
+coeff = randn()
+opS = Scale(coeff, opD)
+x1 = randn(n1)
+x2 = randn(n2)
+y = test_op(opS, ArrayPartition(x1, x2), ArrayPartition(randn(m1), randn(m2)), verb)
+z = ArrayPartition(coeff*A1*x1, coeff*A2*x2)
+
+@test norm(y - z) <= 1e-12
+
+# test Scale of VCAT
+
+m1, m2, n = 4, 3, 7
+A1 = randn(m1, n)
+A2 = randn(m2, n)
+opA1 = MatrixOp(A1)
+opA2 = MatrixOp(A2)
+opV = VCAT(opA1, opA2)
+coeff = randn()
+opS = Scale(coeff, opV)
+x = randn(n)
+y = test_op(opS, x, ArrayPartition(randn(m1), randn(m2)), verb)
+z = ArrayPartition(coeff*A1*x, coeff*A2*x)
+
+@test norm(y - z) <= 1e-12
+
+# test Scale of HCAT
+
+m, n1, n2 = 4, 3, 7
+A1 = randn(m, n1)
+A2 = randn(m, n2)
+opA1 = MatrixOp(A1)
+opA2 = MatrixOp(A2)
+opH = HCAT(opA1, opA2)
+coeff = randn()
+opS = Scale(coeff, opH)
+x1 = randn(n1)
+x2 = randn(n2)
+y = test_op(opS, ArrayPartition(x1, x2), randn(m), verb)
+z = coeff*(A1*x1 + A2*x2)
+
+@test norm(y - z) <= 1e-12
+
+# test DCAT of HCATs
+
+m1, m2, n1, n2, l1, l2, l3 = 2,3,4,5,6,7,8
+A1 = randn(m1, n1)
+A2 = randn(m1, n2)
+B1 = randn(m2, n1)
+B2 = randn(m2, n2)
+B3 = randn(m2, n2)
+opA1 = MatrixOp(A1)
+opA2 = MatrixOp(A2)
+opH1 = HCAT(opA1, opA2)
+opB1 = MatrixOp(B1)
+opB2 = MatrixOp(B2)
+opB3 = MatrixOp(B3)
+opH2 = HCAT(opB1, opB2, opB3)
+
+op = DCAT(opA1, opH2)
+x =  ArrayPartition(randn.(size(op,2))...)
+y0 = ArrayPartition(randn.(size(op,1))...)
+y = test_op(op, x, y0, verb)
+
+op = DCAT(opH1, opH2)
+x =  ArrayPartition(randn.(size(op,2))...) 
+y0 = ArrayPartition(randn.(size(op,1))...)
+y = test_op(op, x, y0, verb)
+
+p = randperm(ndoms(op,2))
+y2 = op[p]*ArrayPartition(x.x[p]...)
+
+@test norm(y - y2) <= 1e-8
+
+# test Scale of Sum
+
+m,n = 5,7
+A1 = randn(m,n)
+A2 = randn(m,n)
+opA1 = MatrixOp(A1)
+opA2 = MatrixOp(A2)
+opS = Sum(opA1,opA2)
+coeff = pi
+opSS = Scale(coeff,opS)
+x1 = randn(n)
+y1 = test_op(opSS, x1, randn(m), verb)
+y2 = coeff*(A1*x1+A2*x1)
+@test norm(y1-y2) <= 1e-12
+
+# test Scale of Compose
+
+m1, m2, m3 = 4, 7, 3
+A1 = randn(m2, m1)
+A2 = randn(m3, m2)
+opA1 = MatrixOp(A1)
+opA2 = MatrixOp(A2)
+
+coeff = pi
+opC = Compose(opA2,opA1)
+opS = Scale(coeff,opC)
+x = randn(m1)
+y1 = test_op(opS, x, randn(m3), verb)
+y2 = coeff*(A2*A1*x)
+@test all(norm.(y1 .- y2) .<= 1e-12)
+

--- a/test/test_nonlinear_operators_calculus.jl
+++ b/test/test_nonlinear_operators_calculus.jl
@@ -24,21 +24,20 @@ Y = -A*x
 
 #testing DCAT
 n,m = 4,3
-x = (randn(n),randn(m))
-r = (randn(n),randn(m))
+x = ArrayPartition(randn(n),randn(m))
+r = ArrayPartition(randn(n),randn(m))
 A = randn(n,n)
 B = Sigmoid(Float64,(m,),2)
 op = DCAT(MatrixOp(A),B)
 
 y, grad = test_NLop(op,x,r,verb)
 
-Y = (A*x[1],B*x[2]) 
-@test norm(Y[1]-y[1]) <1e-8
-@test norm(Y[2]-y[2]) <1e-8
+Y = ArrayPartition(A*x.x[1],B*x.x[2]) 
+@test norm(Y-y) <1e-8
 
 #testing HCAT
 n,m = 4,3
-x = (randn(n),randn(m))
+x = ArrayPartition(randn(n),randn(m))
 r = randn(m)
 A = randn(m,n)
 B = Sigmoid(Float64,(m,),2)
@@ -46,11 +45,11 @@ op = HCAT(MatrixOp(A),B)
 
 y, grad = test_NLop(op,x,r,verb)
 
-Y = A*x[1]+B*x[2]
+Y = A*x.x[1]+B*x.x[2]
 @test norm(Y-y) <1e-8
 
 m,n = 3,5
-x = (randn(m),randn(n))
+x = ArrayPartition(randn(m),randn(n))
 r = randn(m)
 A= Sin(Float64,(m,))
 M = randn(m,n)
@@ -59,36 +58,36 @@ op = HCAT(A,B)
 
 y, grad = test_NLop(op,x,r,verb)
 
-Y = A*x[1]+M*x[2]
+Y = A*x.x[1]+M*x.x[2]
 @test norm(Y-y) <1e-8
 
 p = [2,1]
 opP = AbstractOperators.permute(op,p)
-J = Jacobian(opP,x[p])'
+xp = ArrayPartition(x.x[p]...)
+J = Jacobian(opP,xp)'
 println(size(J,1))
-y, grad = test_NLop(opP,x[p],r,verb)
+y, grad = test_NLop(opP,xp,r,verb)
 
 #testing VCAT
 n,m = 4,3
 x = randn(m)
-r = (randn(n),randn(m))
+r = ArrayPartition(randn(n),randn(m))
 A = randn(n,m)
 B = Sigmoid(Float64,(m,),2)
 op = VCAT(MatrixOp(A),B)
 
 y, grad = test_NLop(op,x,r,verb)
 
-Y = (A*x,B*x)
-@test norm(Y[1]-y[1]) <1e-8
-@test norm(Y[2]-y[2]) <1e-8
+Y = ArrayPartition(A*x,B*x)
+@test norm(Y-y) <1e-8
 
 #testing HCAT of VCAT
 n,m1,m2,m3 = 4,3,2,7
 x1 = randn(m1)
 x2 = randn(m2)
 x3 = randn(m3)
-x = (x1,x2,x3)
-r = (randn(n),randn(m1))
+x = ArrayPartition(x1,x2,x3)
+r = ArrayPartition(randn(n),randn(m1))
 A1 = randn(n,m1)
 A2 = randn(n,m2)
 A3 = randn(n,m3)
@@ -102,33 +101,31 @@ op = HCAT(op1,op2,op3)
 
 y, grad = test_NLop(op,x,r,verb)
 
-Y = (A1*x1+A2*x2+A3*x3,B1*x1+B2*x2+B3*x3)
-@test norm(Y[1]-y[1]) <1e-8
-@test norm(Y[2]-y[2]) <1e-8
+Y = ArrayPartition(A1*x1+A2*x2+A3*x3,B1*x1+B2*x2+B3*x3)
+@test norm(Y-y) <1e-8
 
 #testing VCAT of HCAT
 m1,m2,m3,n1,n2 = 3,4,5,6,7
 x1 = randn(m1)
 x2 = randn(n1)
 x3 = randn(m3)
-x = (x1,x2,x3)
-r = (randn(n1),randn(n2))
+x = ArrayPartition(x1,x2,x3)
+r = ArrayPartition(randn(n1),randn(n2))
 A1 = randn(n1,m1)
 B1 = Sigmoid(Float64,(n1,),2)
 C1 = randn(n1,m3)
 A2 = randn(n2,m1)
 B2 = randn(n2,n1) 
 C2 = randn(n2,m3)
-x = (x1,x2,x3)
+x = ArrayPartition(x1,x2,x3)
 op1 = HCAT(MatrixOp(A1),         B1 ,MatrixOp(C1))
 op2 = HCAT(MatrixOp(A2),MatrixOp(B2),MatrixOp(C2))
 op = VCAT(op1,op2)
 
 y, grad = test_NLop(op,x,r,verb)
 
-Y = (A1*x1+B1*x2+C1*x3,A2*x1+B2*x2+C2*x3)
-@test norm(Y[1]-y[1]) <1e-8
-@test norm(Y[2]-y[2]) <1e-8
+Y = ArrayPartition(A1*x1+B1*x2+C1*x3,A2*x1+B2*x2+C2*x3)
+@test norm(Y-y) <1e-8
 
 
 #testing Compose
@@ -152,7 +149,7 @@ Y = A*(opB*(opC*x))
 m,n,l = 4,7,5
 b = randn(l)
 opS1 = Sigmoid(Float64,(n,),2)
-x = (randn(n,l),randn(n))
+x = ArrayPartition(randn(n,l),randn(n))
 r = randn(n)
 
 A1 = HCAT(LMatrixOp(b,n) ,Eye(n))
@@ -208,30 +205,30 @@ y, grad = test_NLop(op,x,r,verb)
 Y = A*x+opB*x
 @test norm(Y-y) <1e-8
 
-## testing NonLinearCompose
+# testing NonLinearCompose
 
-##with vectors inner product
+#with vectors inner product
 n,m = 3,4
-x = (randn(1,m),randn(n))
+x = ArrayPartition(randn(1,m),randn(n))
 A = randn(m,n)
 r = randn(1)
 
 P = NonLinearCompose( Eye(1,m), MatrixOp(A) )
 y, grad = test_NLop(P,x,r,verb)
 
-Y = x[1]*(A*x[2])
+Y = x.x[1]*(A*x.x[2])
 @test norm(Y - y) <= 1e-12
 
 ##with vectors outer product
 n, m = 3, 5
-x = (randn(n),randn(1,m))
+x = ArrayPartition(randn(n),randn(1,m))
 r = randn(n,m)
 
 L1, L2 = Eye(n), Eye(1,m)
 P = NonLinearCompose(L1, L2)
 y, grad = test_NLop(P,x,r,verb)
 
-Y = x[1]*x[2]
+Y = x.x[1]*x.x[2]
 @test norm(Y - y) <= 1e-12
 
 opM = MatrixOp(randn(1,3))
@@ -239,11 +236,11 @@ A  = opM
 B  = Eye((1,)) 
 
 L = NonLinearCompose(A, B)
-x = randn.(size(L,2)) 
+x = ArrayPartition(randn.(size(L,2))...)
 y, grad = test_NLop(L,x,[1.],verb)
 
 L = NonLinearCompose(B, A)
-x = randn.(size(L,2)) 
+x = ArrayPartition(randn.(size(L,2))...) 
 y, grad = test_NLop(L,x,[1.],verb)
 
 L1, L2 = Eye(n), Eye(2,m)
@@ -257,7 +254,7 @@ L1, L2 = Eye(1,m), Eye(n,m)
 
 #with matrices
 l,m1,m2,n1,n2 = 2,3,4,5,6
-x = (randn(m1,m2),randn(n1,n2))
+x = ArrayPartition(randn(m1,m2),randn(n1,n2))
 A = randn(l,m1)
 B = randn(m2,n1)
 r = randn(l,n2)
@@ -265,17 +262,16 @@ r = randn(l,n2)
 P = NonLinearCompose( MatrixOp(A,m2), MatrixOp(B,n2) )
 y, grad = test_NLop(P,x,r,verb)
 
-Y = A*x[1]*B*x[2]
+Y = A*x.x[1]*B*x.x[2]
 @test norm(Y - y) <= 1e-12
 
 #further test on gradient with analytical formulas
-grad2 =  (A'*r)*(B*x[2])', B'*(A*x[1])'*r
-@test norm(grad[1]-grad2[1]) <1e-7
-@test norm(grad[2]-grad2[2]) <1e-7
+grad2 =  ArrayPartition((A'*r)*(B*x.x[2])', B'*(A*x.x[1])'*r)
+@test norm(grad-grad2) <1e-7
 
 #with complex matrices
 l,m1,m2,n1,n2 = 2,3,4,5,6
-x = (randn(m1,m2)+im*randn(m1,m2),randn(n1,n2)+im*randn(n1,n2))
+x = ArrayPartition(randn(m1,m2)+im*randn(m1,m2),randn(n1,n2)+im*randn(n1,n2))
 A = randn(l,m1) +im*randn(l,m1)
 B = randn(m2,n1)+im*randn(m2,n1)
 r = randn(l,n2) +im*randn(l,n2)
@@ -283,17 +279,16 @@ r = randn(l,n2) +im*randn(l,n2)
 P = NonLinearCompose( MatrixOp(A,m2), MatrixOp(B,n2) )
 y, grad = test_NLop(P,x,r,verb)
 
-Y = A*x[1]*B*x[2]
+Y = A*x.x[1]*B*x.x[2]
 @test norm(Y - y) <= 1e-12
 
 ##test on gradient with analytical formulas
-grad2 =  (A'*r)*(B*x[2])', B'*(A*x[1])'*r
-@test norm(grad[1]-grad2[1]) <1e-7
-@test norm(grad[2]-grad2[2]) <1e-7
+grad2 =  ArrayPartition((A'*r)*(B*x.x[2])', B'*(A*x.x[1])'*r)
+@test norm(grad-grad2) <1e-7
 
 #nested NonLinearOp
 l1,l2,m1,m2,n1,n2 = 2,3,4,5,6,7
-x = (randn(l1,l2),randn(m1,m2),randn(n1,n2))
+x = ArrayPartition(randn(l1,l2),randn(m1,m2),randn(n1,n2))
 A = randn(l2,l1)
 B = randn(l2,m1)
 C = randn(m2,n1)
@@ -303,18 +298,21 @@ P1  = NonLinearCompose( MatrixOp(B,m2), MatrixOp(C,n2) )
 P = NonLinearCompose( MatrixOp(A,l2), P1 )
 y, grad = test_NLop(P,x,r,verb)
 
-Y = A*x[1]*B*x[2]*C*x[3]
+Y = A*x.x[1]*B*x.x[2]*C*x.x[3]
 @test norm(Y - y) <= 1e-12
 
 #further test on gradient with analytical formulas
-grad2 =  A'*(r*(B*x[2]*C*x[3])'), B'*((r'*A*x[1])'*(C*x[3])'), C'*(B*x[2])'*(A*x[1])'*r
-@test norm(grad[1]-grad2[1]) <1e-7
-@test norm(grad[2]-grad2[2]) <1e-7
-@test norm(grad[3]-grad2[3]) <1e-7
+grad2 =  ArrayPartition(
+                        A'*(r*(B*x.x[2]*C*x.x[3])'), 
+                        B'*((r'*A*x.x[1])'*(C*x.x[3])'), 
+                        C'*(B*x.x[2])'*(A*x.x[1])'*r
+                       )
+@test norm(grad-grad2) <1e-7
 
-p = randperm(length(x))
+p = randperm(length(x.x))
 Pp = AbstractOperators.permute(P,p)
-y, grad = test_NLop(Pp,x[p],r,verb)
+xp = ArrayPartition(x.x[p]...)
+y, grad = test_NLop(Pp,xp,r,verb)
 
 ## DNN
 m,n,l = 4,7,5
@@ -331,16 +329,17 @@ A3 = NonLinearCompose(Eye(m,n) , L2)
 L3 = Compose(opS3,A3)
 
 r = randn(m) 
-x = randn.(size(L3,2)) 
+x = ArrayPartition(randn.(size(L3,2))...) 
 
 y, grad = test_NLop(L3,x,r,verb)
 
-Y = opS3*(x[1]*(opS2*(x[2]*(opS1*(x[3]*b+x[4])))))
+Y = opS3*(x.x[1]*(opS2*(x.x[2]*(opS1*(x.x[3]*b+x.x[4])))))
 @test norm(Y - y) <= 1e-12
 
-p = randperm(length(x))
+p = randperm(length(x.x))
 L3p = AbstractOperators.permute(L3,p)
-y, grad = test_NLop(L3p,x[p],r,verb)
+xp = ArrayPartition(x.x[p]...)
+y, grad = test_NLop(L3p,xp,r,verb)
 
 # Hadamard
 l,m,n = 10,3,7
@@ -349,15 +348,16 @@ op2 = MatrixOp(randn(n,l))
 H = Hadamard(op1,op2)
 
 r = randn(n) 
-x = randn.(size(H,2)) 
+x = ArrayPartition(randn.(size(H,2))...) 
 
 y, grad = test_NLop(H,x,r,verb)
-@test norm(y-(op1.A*x[1]).*(op2.A*x[2])) < 1e-9
+@test norm(y-(op1.A*x.x[1]).*(op2.A*x.x[2])) < 1e-9
 
 p = [2;1]
 Hp = AbstractOperators.permute(H,p)
-y, grad = test_NLop(Hp,x[p],r,verb)
-@test norm(y-(op1.A*x[1]).*(op2.A*x[2])) < 1e-9
+xp = ArrayPartition(x.x[p]...)
+y, grad = test_NLop(Hp,xp,r,verb)
+@test norm(y-(op1.A*x.x[1]).*(op2.A*x.x[2])) < 1e-9
 
 l,m,n = 10,3,7
 op1 = MatrixOp(randn(n,m))
@@ -366,15 +366,16 @@ op3 = DCT(n)
 H = Hadamard(Hadamard(op1,op2),op3)
 
 r = randn(n) 
-x = randn.(size(H,2)) 
+x = ArrayPartition(randn.(size(H,2))...)
 
 y, grad = test_NLop(H,x,r,verb)
-@test norm(y-(op1.A*x[1]).*(op2.A*x[2]).*(op3.A*x[3])) < 1e-9
+@test norm(y-(op1.A*x.x[1]).*(op2.A*x.x[2]).*(op3.A*x.x[3])) < 1e-9
 
 p = [2;1;3]
 Hp = AbstractOperators.permute(H,p)
-y, grad = test_NLop(Hp,x[p],r,verb)
-@test norm(y-(op1.A*x[1]).*(op2.A*x[2]).*(op3.A*x[3])) < 1e-9
+xp = ArrayPartition(x.x[p]...)
+y, grad = test_NLop(Hp,xp,r,verb)
+@test norm(y-(op1.A*x.x[1]).*(op2.A*x.x[2]).*(op3.A*x.x[3])) < 1e-9
 
 l,m,n = 10,3,7
 A = randn(n,m)+im*randn(n,m)
@@ -382,10 +383,10 @@ op1 = MatrixOp(A)
 op3 = AbstractOperators.DFT(n)
 H = Hadamard(op1,op3)
 
-x = randn(m)+im*randn(m),randn(n)
+x = ArrayPartition(randn(m)+im*randn(m),randn(n))
 
 y = H*x
-@test norm(y - (A*x[1]).*(fft(x[2])) ) <1e-9
+@test norm(y - (A*x.x[1]).*(fft(x.x[2])) ) <1e-9
 grad = Jacobian(H,x)'*y
 # TODO add test on gradient
 
@@ -397,12 +398,13 @@ opB = MatrixOp(randn(n,m2))
 op2 = HCAT(opA,opB)
 H = Hadamard(op1,op2)
 r = randn(n) 
-x = randn.(size(H,2)) 
+x = ArrayPartition(randn.(size(H,2))... )
 y, grad = test_NLop(H,x,r,verb)
 
 p = [2;1;3]
 Hp = AbstractOperators.permute(H,p)
-y, grad = test_NLop(Hp,x[p],r,verb)
+xp = ArrayPartition(x.x[p]...)
+y, grad = test_NLop(Hp,xp,r,verb)
 
 ## Hadamard of Hadamard with NonLinear operators
 n = 10
@@ -413,7 +415,7 @@ H1  = Hadamard(opA,opB)
 H   = Hadamard(op1,H1)
 
 r = randn(n) 
-x = randn.(size(H,2)) 
+x = ArrayPartition(randn.(size(H,2))...)
 y, grad = test_NLop(H,x,r,verb)
 
 ## AffineAdd and NonLinearOperator
@@ -450,7 +452,7 @@ y, grad = test_NLop(T,x,r,verb)
 
 ## AffineAdd and NonLinearCompose
 l,m1,m2,n1,n2 = 2,3,4,5,6
-x = (randn(m1,m2),randn(n1,n2))
+x = ArrayPartition(randn(m1,m2),randn(n1,n2))
 A = randn(l,m1)
 B = randn(m2,n1)
 d1 = randn(l,m2)
@@ -460,17 +462,17 @@ r = randn(l,n2)
 P = NonLinearCompose( AffineAdd(MatrixOp(A,m2),d1), AffineAdd(MatrixOp(B,n2),d2) )
 y, grad = test_NLop(P,x,r,verb)
 
-Y = (A*x[1]+d1)*(B*x[2]+d2)
+Y = (A*x.x[1]+d1)*(B*x.x[2]+d2)
 @test norm(Y - y) <= 1e-12
 
 y, grad = test_NLop(remove_displacement(P),x,r,verb)
 
-Y = (A*x[1])*(B*x[2])
+Y = (A*x.x[1])*(B*x.x[2])
 @test norm(Y - y) <= 1e-12
 
 ## AffineAdd and NonLinearCompose and Compose
 l,m1,m2,n1,n2 = 2,3,4,5,6
-x = (randn(m1,m2),randn(n1,n2))
+x = ArrayPartition(randn(m1,m2),randn(n1,n2))
 A = randn(l,m1)
 B = randn(m2,n1)
 d1, d2 = randn(m1,m2), randn(n1,n2)
@@ -482,17 +484,17 @@ P = NonLinearCompose(
                     )
 y, grad = test_NLop(P,x,r,verb)
 
-Y = (A*(x[1]+d1))*(B*(x[2]+d2))
+Y = (A*(x.x[1]+d1))*(B*(x.x[2]+d2))
 @test norm(Y - y) <= 1e-12
 
 y, grad = test_NLop(remove_displacement(P),x,r,verb)
 
-Y = (A*(x[1]))*(B*(x[2]))
+Y = (A*(x.x[1]))*(B*(x.x[2]))
 @test norm(Y - y) <= 1e-12
 
 ## AffineAdd and Hadamard
 n,m,l = 3,4,7
-x = (randn(n),randn(m))
+x = ArrayPartition(randn(n),randn(m))
 A = randn(l,n)
 B = randn(l,m)
 d1 = randn(l)
@@ -502,17 +504,17 @@ r = randn(l)
 P = Hadamard( AffineAdd(MatrixOp(A),d1), AffineAdd(MatrixOp(B),d2) )
 y, grad = test_NLop(P,x,r,verb)
 
-Y = (A*x[1]+d1).*(B*x[2]+d2)
+Y = (A*x.x[1]+d1).*(B*x.x[2]+d2)
 @test norm(Y - y) <= 1e-12
 
 y, grad = test_NLop(remove_displacement(P),x,r,verb)
 
-Y = (A*x[1]).*(B*x[2])
+Y = (A*x.x[1]).*(B*x.x[2])
 @test norm(Y - y) <= 1e-12
 
 ## AffineAdd and Hadamard and Compose
 n,m,l = 3,4,7
-x = (randn(n),randn(m))
+x = ArrayPartition(randn(n),randn(m))
 A = randn(l,n)
 B = randn(l,m)
 d1 = randn(n)
@@ -525,10 +527,42 @@ P = Hadamard(
             )
 y, grad = test_NLop(P,x,r,verb)
 
-Y = (A*(x[1]+d1)).*(B*(x[2]-d2))
+Y = (A*(x.x[1]+d1)).*(B*(x.x[2]-d2))
 @test norm(Y - y) <= 1e-12
 
 y, grad = test_NLop(remove_displacement(P),x,r,verb)
 
-Y = (A*(x[1])).*(B*(x[2]))
+Y = (A*(x.x[1])).*(B*(x.x[2]))
 @test norm(Y - y) <= 1e-12
+
+## Reshape AffineAdd and NonLinearCompose
+l,m1,m2,n1,n2 = 2,3,4,5,6
+x = ArrayPartition(randn(m1,m2),randn(n1,n2))
+A = randn(l,m1)
+B = randn(m2,n1)
+d1 = randn(l,m2)
+d2 = randn(m2,n2)
+r = randn(l*n2)
+
+P = Reshape(
+            NonLinearCompose( AffineAdd(MatrixOp(A,m2),d1), AffineAdd(MatrixOp(B,n2),d2) ),
+            l*n2)
+y, grad = test_NLop(P,x,r,verb)
+
+Y = (A*x.x[1]+d1)*(B*x.x[2]+d2)
+@test norm(Y[:] - y) <= 1e-12
+
+y, grad = test_NLop(remove_displacement(P),x,r,verb)
+
+Y = (A*x.x[1])*(B*x.x[2])
+@test norm(Y[:] - y) <= 1e-12
+
+p = [2,1]
+opP = AbstractOperators.permute(P,p)
+xp = ArrayPartition(x.x[p]...)
+y, grad = test_NLop(opP,xp,r,verb)
+
+Y = (A*x.x[1]+d1)*(B*x.x[2]+d2)
+@test norm(Y[:] - y) <= 1e-12
+
+

--- a/test/test_syntax.jl
+++ b/test/test_syntax.jl
@@ -156,7 +156,7 @@ opB = MatrixOp(B)
 opC = MatrixOp(C)
 opH = HCAT(opA,opB,opC)
 opH2 = opH[1:2]
-y1 = opH2*(x1,x2)
+y1 = opH2*ArrayPartition(x1,x2)
 y2 = A*x1+B*x2
 @test all(norm.(y1 .- y2) .<= 1e-12)
 opH3 = opH[3]
@@ -165,14 +165,14 @@ y2 = C*x3
 @test all(norm.(y1 .- y2) .<= 1e-12)
 
 opHperm = opH[[3,1,2]]
-@test norm(opH*(x1,x2,x3) - opHperm*(x3,x1,x2)) <1e-12
+@test norm(opH*ArrayPartition(x1,x2,x3) - opHperm*ArrayPartition(x3,x1,x2)) <1e-12
 
 @test opHperm[1] == opC
 @test opHperm[2] == opA
 @test opHperm[3] == opB
 
 opHperm = opH[[3,1]]
-@test norm(opC*x3+opA*x1 - opHperm*(x3,x1)) <1e-12
+@test norm(opC*x3+opA*x1 - opHperm*ArrayPartition(x3,x1)) <1e-12
 
 # slicing Affine add of HCAT
 d = randn(n)
@@ -209,12 +209,12 @@ opC = MatrixOp(C)
 opV = VCAT(opA,opB,opC)
 opV2 = opV[1:2]
 y1 = opV2*x1
-y2 = (A*x1,B*x1)
-@test all(norm.(y1 .- y2) .<= 1e-12)
+y2 = ArrayPartition(A*x1,B*x1)
+@test norm(y1 - y2) <= 1e-12
 opV3 = opV[3]
 y1 = opV3*x3
 y2 = C*x3
-@test all(norm.(y1 .- y2) .<= 1e-12)
+@test norm(y1 - y2) <= 1e-12
 
 ###### hcat ######
 
@@ -226,14 +226,14 @@ opB = MatrixOp(B)
 opH = [opA opB]
 x1 = randn(m1)
 x2 = randn(m2)
-y1 = opH*(x1,x2)
+y1 = opH*ArrayPartition(x1,x2)
 y2 = [A B]*[x1;x2]
-@test all(norm.(y1 .- y2) .<= 1e-12)
+@test norm(y1 - y2) <= 1e-12
 
 opHH = [opH opB]
-y1 = opHH*(x1, x2, x2)
+y1 = opHH*ArrayPartition(x1, x2, x2)
 y2 = [A B B]*[x1;x2;x2]
-@test all(norm.(y1 .- y2) .<= 1e-12)
+@test norm(y1 - y2) <= 1e-12
 
 ###### vcat ######
 
@@ -245,13 +245,13 @@ opB = MatrixOp(B)
 opH = [opA; opB]
 x1 = randn(n)
 y1 = opH*x1
-y2 = (A*x1,B*x1)
-@test all(norm.(y1 .- y2) .<= 1e-12)
+y2 = ArrayPartition(A*x1,B*x1)
+@test norm(y1 - y2) <= 1e-12
 
 opVV = [opA; opH]
 y1 = opVV*x1
-y2 = (A*x1, A*x1, B*x1)
-@test all(norm.(y1 .- y2) .<= 1e-12)
+y2 = ArrayPartition(A*x1, A*x1, B*x1)
+@test norm(y1 - y2) <= 1e-12
 
 ###### reshape ######
 n,m =  10,5
@@ -262,7 +262,7 @@ opR = reshape(opA,2,5)
 opR = reshape(opA,(2,5))
 y1 = opR*x1
 y2 = reshape(A*x1,2,5)
-@test all(norm.(y1 .- y2) .<= 1e-12)
+@test norm(y1 - y2) <= 1e-12
 
 # testing ndims & ndoms
 L = Variation((3,4,5))

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -111,7 +111,7 @@ function gradient_fd(op::A,
                      x0::AbstractArray, 
                      r::ArrayPartition) where {A<:AbstractOperator} 
   N = length(y0.x)
-	grad = 0 .*similar(x0)
+	grad = zero(x0)
 	y    = 0 .*similar(y0)
 	J = [ zeros(*(sz1...),*(size(op,2)...)) for sz1 in size(op,1)]
 

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -134,7 +134,7 @@ function gradient_fd(op::A,
                      y0::ArrayPartition, 
                      x0::ArrayPartition, 
                      r::ArrayPartition) where {A<:AbstractOperator} 
-	grad = 0 .*similar(x0)
+	grad = zero(x0)
 	y    = 0 .*similar(y0)
   M = length(x0.x)
   N = length(y0.x)

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -112,7 +112,7 @@ function gradient_fd(op::A,
                      r::ArrayPartition) where {A<:AbstractOperator} 
   N = length(y0.x)
 	grad = zero(x0)
-	y    = 0 .*similar(y0)
+	y    = zero(y0)
 	J = [ zeros(*(sz1...),*(size(op,2)...)) for sz1 in size(op,1)]
 
 	h = sqrt(eps())

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -90,7 +90,7 @@ function gradient_fd(op::A,
                      r::AbstractArray) where {A<:AbstractOperator} 
   N = length(x0.x)
 	y = copy(y0)
-	grad = 0 .*similar(x0)
+	grad = zero(x0)
 	J =  [ zeros(*(size(op,1)...),*(sz2...)) for sz2 in size(op,2)]
 
 	h = sqrt(eps())

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -135,7 +135,7 @@ function gradient_fd(op::A,
                      x0::ArrayPartition, 
                      r::ArrayPartition) where {A<:AbstractOperator} 
 	grad = zero(x0)
-	y    = 0 .*similar(y0)
+	y    = zero(y0)
   M = length(x0.x)
   N = length(y0.x)
 	J = [ zeros(*(size(op,1)[i]...),*(size(op,2)[ii]...)) for ii = 1:M, i = 1:N ]


### PR DESCRIPTION
Addressing #5 and #7 and #9 

I'm convinced that removing completely operations with Tuples is the way to go, like these ones:
* `A*(x,y)` -> `A*ArrayParition(x,y)`
* `mul!(y::Tuple, A::AbstractOperators, b::Tuple)` -> `mul!(y::ArrayParition, A::AbstractOperators, b::ArrayParition)`
*  etc..

The reason is that the notation compatibility between `Tuples` and `ArrayPartitions` isn't the best.
`ArrayPartition` employs a different redefinition of `getindex`: if `typeof(x) <: ArrayParition`, `x[1]` will not give you the first array of the collection but the first element of the first array. So to avoid confusion in the code I would avoid working with Tuples of Arrays at all.

That being said, I'm quite in favor of using `ArrayParitions`: although this will mean breaking changes in `StruturedOptimization`, it will possibly lead to many simplifications since `ArrayPartion <: AbstractArray`. We can already see some in the LBFGS (where dots can now be employed) and in Sum.
 
TODO: if we decide to completely remove multiplication with Tuples (which I think is the way to go), update docs accordingly 