### PR TITLE
Adding dims to DFT/IDFT operator

### DIFF
--- a/src/linearoperators/DFT.jl
+++ b/src/linearoperators/DFT.jl
@@ -3,20 +3,20 @@ export DFT, IDFT
 abstract type FourierTransform{N,C,D,T1,T2} <: LinearOperator end
 
 """
-`DFT([domainType=Float64::Type,] dim_in::Tuple)`
+`DFT([domainType=Float64::Type,] dim_in::Tuple [,dims])`
 
 `DFT(dim_in...)`
 
-`DFT(x::AbstractArray)`
+`DFT(x::AbstractArray, [,dims])`
 
-Creates a `LinearOperator` which, when multiplied with an array `x::AbstractArray{N}`, returns the `N`-dimensional Discrete Fourier Transform of `x`. 
+Creates a `LinearOperator` which, when multiplied with an array `x::AbstractArray{N}`, returns the `N`-dimensional Discrete Fourier Transform over dimensions `dims` of `x`.
 
 ```julia
 julia> DFT(Complex{Float64},(10,10))
-ℱ  ℂ^(10, 10) -> ℂ^(10, 10) 
+ℱ  ℂ^(10, 10) -> ℂ^(10, 10)
 
 julia> DFT(10,10)
-ℱ  ℝ^(10, 10) -> ℂ^(10, 10) 
+ℱ  ℝ^(10, 10) -> ℂ^(10, 10)
 
 julia> A = DFT(ones(3))
 ℱ  ℝ^3 -> ℂ^3
@@ -47,14 +47,14 @@ end
 
 `IDFT(x::AbstractArray)`
 
-Creates a `LinearOperator` which, when multiplied with an array `x::AbstractArray{N}`, returns the `N`-dimensional Inverse Discrete Fourier Transform of `x`. 
+Creates a `LinearOperator` which, when multiplied with an array `x::AbstractArray{N}`, returns the `N`-dimensional Inverse Discrete Fourier Transform of `x`.
 
 ```julia
 julia> IDFT(Complex{Float64},(10,10))
-ℱ⁻¹  ℂ^(10, 10) -> ℂ^(10, 10) 
+ℱ⁻¹  ℂ^(10, 10) -> ℂ^(10, 10)
 
 julia> IDFT(10,10)
-ℱ⁻¹ ℝ^(10, 10) -> ℂ^(10, 10) 
+ℱ⁻¹ ℝ^(10, 10) -> ℂ^(10, 10)
 
 julia> A = IDFT(ones(3))
 ℱ⁻¹  ℝ^3 -> ℂ^3
@@ -79,36 +79,36 @@ end
 
 # Constructors
 #standard constructor
-DFT(dim_in::NTuple{N,Int}) where {N} = DFT(zeros(dim_in))
+DFT(dim_in::NTuple{N,Int},dims=1:N) where {N} = DFT(zeros(dim_in),dims)
 
-function DFT(x::AbstractArray{D,N}) where {N,D<:Real}
-	A,At = plan_fft(x), plan_bfft(fft(x))
+function DFT(x::AbstractArray{D,N},dims=1:ndims(x)) where {N,D<:Real}
+	A,At = plan_fft(x,dims), plan_bfft(fft(x,dims),dims)
 	DFT{N,Complex{D},D,typeof(A),typeof(At)}(size(x),A,At)
 end
 
-function DFT(x::AbstractArray{D,N}) where {N,D<:Complex}
-	A,At = plan_fft(x), plan_bfft(fft(x))
+function DFT(x::AbstractArray{D,N},dims=1:ndims(x)) where {N,D<:Complex}
+	A,At = plan_fft(x,dims), plan_bfft(fft(x,dims),dims)
 	DFT{N,D,D,typeof(A),typeof(At)}(size(x),A,At)
 end
 
-DFT(T::Type,dim_in::NTuple{N,Int}) where {N} = DFT(zeros(T,dim_in))
+DFT(T::Type,dim_in::NTuple{N,Int},dims=1:N) where {N} = DFT(zeros(T,dim_in),dims)
 DFT(dim_in::Vararg{Int}) = DFT(dim_in)
 DFT(T::Type,dim_in::Vararg{Int}) = DFT(T,dim_in)
 
-function IDFT(x::AbstractArray{D,N}) where {N,D<:Real}
-	A,At = plan_ifft(x), plan_fft(ifft(x))
+function IDFT(x::AbstractArray{D,N},dims=1:ndims(x)) where {N,D<:Real}
+	A,At = plan_ifft(x,dims), plan_fft(ifft(x,dims),dims)
 	IDFT{N,Complex{D},D,typeof(A),typeof(At)}(size(x),A,At)
 end
 
 #standard constructor
-IDFT(T::Type,dim_in::NTuple{N,Int}) where {N} = IDFT(zeros(T,dim_in))
+IDFT(T::Type,dim_in::NTuple{N,Int},dims=1:N) where {N} = IDFT(zeros(T,dim_in),dims)
 
-function IDFT(x::AbstractArray{D,N}) where {N,D<:Complex}
-	A,At = plan_ifft(x), plan_fft(ifft(x))
+function IDFT(x::AbstractArray{D,N},dims=1:ndims(x)) where {N,D<:Complex}
+	A,At = plan_ifft(x,dims), plan_fft(ifft(x,dims),dims)
 	IDFT{N,D,D,typeof(A),typeof(At)}(size(x),A,At)
 end
 
-IDFT(dim_in::NTuple{N,Int}) where {N} = IDFT(zeros(dim_in))
+IDFT(dim_in::NTuple{N,Int},dims=1:N) where {N} = IDFT(zeros(dim_in),dims)
 IDFT(dim_in::Vararg{Int}) = IDFT(dim_in)
 IDFT(T::Type,dim_in::Vararg{Int}) = IDFT(T,dim_in)
 

--- a/src/linearoperators/DFT.jl
+++ b/src/linearoperators/DFT.jl
@@ -7,7 +7,7 @@ abstract type FourierTransform{N,C,D,T1,T2} <: LinearOperator end
 
 `DFT(dim_in...)`
 
-`DFT(x::AbstractArray, [,dims])`
+`DFT(x::AbstractArray [,dims])`
 
 Creates a `LinearOperator` which, when multiplied with an array `x::AbstractArray{N}`, returns the `N`-dimensional Discrete Fourier Transform over dimensions `dims` of `x`.
 
@@ -41,11 +41,11 @@ end
 
 
 """
-`IDFT([domainType=Float64::Type,] dim_in::Tuple)`
+`IDFT([domainType=Float64::Type,] dim_in::Tuple [,dims])`
 
 `IDFT(dim_in...)`
 
-`IDFT(x::AbstractArray)`
+`IDFT(x::AbstractArray [,dims])`
 
 Creates a `LinearOperator` which, when multiplied with an array `x::AbstractArray{N}`, returns the `N`-dimensional Inverse Discrete Fourier Transform over dimensions `dims` of `x`.
 

--- a/src/linearoperators/DFT.jl
+++ b/src/linearoperators/DFT.jl
@@ -1,6 +1,6 @@
 export DFT, IDFT
 
-abstract type FourierTransform{N,C,D,E,T1,T2} <: LinearOperator end
+abstract type FourierTransform{N,C,D,T1,T2} <: LinearOperator end
 
 """
 `DFT([domainType=Float64::Type,] dim_in::Tuple [,dims])`
@@ -32,9 +32,8 @@ julia> A*ones(3)
 struct DFT{N,
 	      C<:RealOrComplex,
 	      D<:RealOrComplex,
-		  E,
 	      T1<:AbstractFFTs.Plan,
-	      T2<:AbstractFFTs.Plan} <: FourierTransform{N,C,D,E,T1,T2}
+	      T2<:AbstractFFTs.Plan} <: FourierTransform{N,C,D,T1,T2}
 	dim_in::NTuple{N,Int}
 	A::T1
 	At::T2
@@ -71,9 +70,8 @@ julia> A*ones(3)
 struct IDFT{N,
 	       C<:RealOrComplex,
 	       D<:RealOrComplex,
-		   E,
 	       T1<:AbstractFFTs.Plan,
-	       T2<:AbstractFFTs.Plan} <: FourierTransform{N,C,D,E,T1,T2}
+	       T2<:AbstractFFTs.Plan} <: FourierTransform{N,C,D,T1,T2}
 	dim_in::NTuple{N,Int}
 	A::T1
 	At::T2
@@ -84,19 +82,13 @@ end
 DFT(dim_in::NTuple{N,Int},dims=1:N) where {N} = DFT(zeros(dim_in),dims)
 
 function DFT(x::AbstractArray{D,N},dims=1:ndims(x)) where {N,D<:Real}
-	y2 = zeros(complex(D),size(x))
-	A = plan_fft(x,dims)
-	At = plan_bfft(y2,dims)
-	dim_in = size(x)
-	DFT{N,Complex{D},D,dims,typeof(A),typeof(At)}(dim_in,A,At)
+	A,At = plan_fft(x,dims), plan_bfft(fft(x,dims),dims)
+	DFT{N,Complex{D},D,typeof(A),typeof(At)}(size(x),A,At)
 end
 
 function DFT(x::AbstractArray{D,N},dims=1:ndims(x)) where {N,D<:Complex}
-	y2 = zeros(D,size(x))
-	A = plan_fft(x,dims)
-	At = plan_bfft(y2,dims)
-	dim_in = size(x)
-	DFT{N,D,D,dims,typeof(A),typeof(At)}(dim_in,A,At)
+	A,At = plan_fft(x,dims), plan_bfft(fft(x,dims),dims)
+	DFT{N,D,D,typeof(A),typeof(At)}(size(x),A,At)
 end
 
 DFT(T::Type,dim_in::NTuple{N,Int},dims=1:N) where {N} = DFT(zeros(T,dim_in),dims)
@@ -104,22 +96,16 @@ DFT(dim_in::Vararg{Int}) = DFT(dim_in)
 DFT(T::Type,dim_in::Vararg{Int}) = DFT(T,dim_in)
 
 function IDFT(x::AbstractArray{D,N},dims=1:ndims(x)) where {N,D<:Real}
-	y2 = zeros(complex(D),size(x))
-	A = plan_ifft(x,dims)
-	At = plan_fft(y2,dims)
-	dim_in = size(x)
-	IDFT{N,Complex{D},D,dims,typeof(A),typeof(At)}(dim_in,A,At)
+	A,At = plan_ifft(x,dims), plan_fft(ifft(x,dims),dims)
+	IDFT{N,Complex{D},D,typeof(A),typeof(At)}(size(x),A,At)
 end
 
 #standard constructor
 IDFT(T::Type,dim_in::NTuple{N,Int},dims=1:N) where {N} = IDFT(zeros(T,dim_in),dims)
 
 function IDFT(x::AbstractArray{D,N},dims=1:ndims(x)) where {N,D<:Complex}
-	y2 = zeros(D,size(x))
-	A = plan_ifft(x,dims)
-	At = plan_fft(y2,dims)
-	dim_in = size(x)
-	IDFT{N,D,D,dims,typeof(A),typeof(At)}(dim_in,A,At)
+	A,At = plan_ifft(x,dims), plan_fft(ifft(x,dims),dims)
+	IDFT{N,D,D,typeof(A),typeof(At)}(size(x),A,At)
 end
 
 IDFT(dim_in::NTuple{N,Int},dims=1:N) where {N} = IDFT(zeros(dim_in),dims)
@@ -129,57 +115,57 @@ IDFT(T::Type,dim_in::Vararg{Int}) = IDFT(T,dim_in)
 # Mappings
 
 function mul!(y::AbstractArray{C,N},
-              L::DFT{N,C,C,E,T1,T2},
-              b::AbstractArray{C,N}) where {N,C<:Complex,E,T1,T2}
+              L::DFT{N,C,C,T1,T2},
+              b::AbstractArray{C,N}) where {N,C<:Complex,T1,T2}
 	mul!(y,L.A,b)
 end
 
 function mul!(y::AbstractArray{C,N},
-              L::DFT{N,C,D,E,T1,T2},
-              b::AbstractArray{D,N}) where {N,C<:Complex,D<:Real,E,T1,T2}
+              L::DFT{N,C,D,T1,T2},
+              b::AbstractArray{D,N}) where {N,C<:Complex,D<:Real,T1,T2}
 	mul!(y,L.A,complex(b))
 end
 
 function mul!(y::AbstractArray{C,N},
-              L::AdjointOperator{DFT{N,C,C,E,T1,T2}},
-              b::AbstractArray{C,N}) where {N,C<:Complex,E,T1,T2}
+              L::AdjointOperator{DFT{N,C,C,T1,T2}},
+              b::AbstractArray{C,N}) where {N,C<:Complex,T1,T2}
 	mul!(y,L.A.At,b)
 end
 
 function mul!(y::AbstractArray{D,N},
-              L::AdjointOperator{DFT{N,C,D,E,T1,T2}},
-              b::AbstractArray{C,N}) where {N,C<:Complex,D<:Real,E,T1,T2}
+              L::AdjointOperator{DFT{N,C,D,T1,T2}},
+              b::AbstractArray{C,N}) where {N,C<:Complex,D<:Real,T1,T2}
 	y2 = complex(y)
 	mul!(y2,L.A.At,b)
 	y .= real.(y2)
 end
 
 function mul!(y::AbstractArray{C,N},
-              L::IDFT{N,C,C,E,T1,T2},
-              b::AbstractArray{C,N}) where {N,C<:Complex,E,T1,T2}
+              L::IDFT{N,C,C,T1,T2},
+              b::AbstractArray{C,N}) where {N,C<:Complex,T1,T2}
 	mul!(y,L.A,b)
 end
 
 function mul!(y::AbstractArray{C,N},
-              L::IDFT{N,C,D,E,T1,T2},
-              b::AbstractArray{D,N}) where {N,C<:Complex,D<:Real,E,T1,T2}
+              L::IDFT{N,C,D,T1,T2},
+              b::AbstractArray{D,N}) where {N,C<:Complex,D<:Real,T1,T2}
 	mul!(y,L.A,complex(b))
 end
 
 function mul!(y::AbstractArray{C,N},
-              L::AdjointOperator{IDFT{N,C,C,E,T1,T2}},
-              b::AbstractArray{C,N}) where {N,C<:Complex,E,T1,T2}
+              L::AdjointOperator{IDFT{N,C,C,T1,T2}},
+              b::AbstractArray{C,N}) where {N,C<:Complex,T1,T2}
 	mul!(y,L.A.At,b)
-	y ./= prod(size(b,e) for e in E)
+	y .*= L.A.A.scale
 end
 
 function mul!(y::AbstractArray{D,N},
-              L::AdjointOperator{IDFT{N,C,D,E,T1,T2}},
-              b::AbstractArray{C,N}) where {N,C<:Complex,D<:Real,E,T1,T2}
+              L::AdjointOperator{IDFT{N,C,D,T1,T2}},
+              b::AbstractArray{C,N}) where {N,C<:Complex,D<:Real,T1,T2}
 
 	y2 = complex(y)
 	mul!(y2,L.A.At,b)
-	y .= (/).(real.(y2), prod(size(b,e) for e in E))
+	y .= real.(y2).*L.A.A.scale
 end
 
 # Properties
@@ -189,8 +175,8 @@ size(L::FourierTransform) = (L.dim_in,L.dim_in)
 fun_name(A::DFT) = "ℱ"
 fun_name(A::IDFT) = "ℱ⁻¹"
 
-domainType(L::FourierTransform{N,C,D,E,T1,T2}) where {N,C,D,E,T1,T2} = D
-codomainType(L::FourierTransform{N,C,D,E,T1,T2}) where {N,C,D,E,T1,T2} = C
+domainType(L::FourierTransform{N,C,D,T1,T2}) where {N,C,D,T1,T2} = D
+codomainType(L::FourierTransform{N,C,D,T1,T2}) where {N,C,D,T1,T2} = C
 
 is_AcA_diagonal(L::FourierTransform)     = true
 is_AAc_diagonal(L::FourierTransform)     = true

--- a/src/linearoperators/DFT.jl
+++ b/src/linearoperators/DFT.jl
@@ -1,6 +1,6 @@
 export DFT, IDFT
 
-abstract type FourierTransform{N,C,D,T1,T2} <: LinearOperator end
+abstract type FourierTransform{N,C,D,E,T1,T2} <: LinearOperator end
 
 """
 `DFT([domainType=Float64::Type,] dim_in::Tuple [,dims])`
@@ -32,8 +32,9 @@ julia> A*ones(3)
 struct DFT{N,
 	      C<:RealOrComplex,
 	      D<:RealOrComplex,
+		  E,
 	      T1<:AbstractFFTs.Plan,
-	      T2<:AbstractFFTs.Plan} <: FourierTransform{N,C,D,T1,T2}
+	      T2<:AbstractFFTs.Plan} <: FourierTransform{N,C,D,E,T1,T2}
 	dim_in::NTuple{N,Int}
 	A::T1
 	At::T2
@@ -47,7 +48,7 @@ end
 
 `IDFT(x::AbstractArray)`
 
-Creates a `LinearOperator` which, when multiplied with an array `x::AbstractArray{N}`, returns the `N`-dimensional Inverse Discrete Fourier Transform of `x`.
+Creates a `LinearOperator` which, when multiplied with an array `x::AbstractArray{N}`, returns the `N`-dimensional Inverse Discrete Fourier Transform over dimensions `dims` of `x`.
 
 ```julia
 julia> IDFT(Complex{Float64},(10,10))
@@ -70,8 +71,9 @@ julia> A*ones(3)
 struct IDFT{N,
 	       C<:RealOrComplex,
 	       D<:RealOrComplex,
+		   E,
 	       T1<:AbstractFFTs.Plan,
-	       T2<:AbstractFFTs.Plan} <: FourierTransform{N,C,D,T1,T2}
+	       T2<:AbstractFFTs.Plan} <: FourierTransform{N,C,D,E,T1,T2}
 	dim_in::NTuple{N,Int}
 	A::T1
 	At::T2
@@ -82,13 +84,19 @@ end
 DFT(dim_in::NTuple{N,Int},dims=1:N) where {N} = DFT(zeros(dim_in),dims)
 
 function DFT(x::AbstractArray{D,N},dims=1:ndims(x)) where {N,D<:Real}
-	A,At = plan_fft(x,dims), plan_bfft(fft(x,dims),dims)
-	DFT{N,Complex{D},D,typeof(A),typeof(At)}(size(x),A,At)
+	y2 = zeros(complex(D),size(x))
+	A = plan_fft(x,dims)
+	At = plan_bfft(y2,dims)
+	dim_in = size(x)
+	DFT{N,Complex{D},D,dims,typeof(A),typeof(At)}(dim_in,A,At)
 end
 
 function DFT(x::AbstractArray{D,N},dims=1:ndims(x)) where {N,D<:Complex}
-	A,At = plan_fft(x,dims), plan_bfft(fft(x,dims),dims)
-	DFT{N,D,D,typeof(A),typeof(At)}(size(x),A,At)
+	y2 = zeros(D,size(x))
+	A = plan_fft(x,dims)
+	At = plan_bfft(y2,dims)
+	dim_in = size(x)
+	DFT{N,D,D,dims,typeof(A),typeof(At)}(dim_in,A,At)
 end
 
 DFT(T::Type,dim_in::NTuple{N,Int},dims=1:N) where {N} = DFT(zeros(T,dim_in),dims)
@@ -96,16 +104,22 @@ DFT(dim_in::Vararg{Int}) = DFT(dim_in)
 DFT(T::Type,dim_in::Vararg{Int}) = DFT(T,dim_in)
 
 function IDFT(x::AbstractArray{D,N},dims=1:ndims(x)) where {N,D<:Real}
-	A,At = plan_ifft(x,dims), plan_fft(ifft(x,dims),dims)
-	IDFT{N,Complex{D},D,typeof(A),typeof(At)}(size(x),A,At)
+	y2 = zeros(complex(D),size(x))
+	A = plan_ifft(x,dims)
+	At = plan_fft(y2,dims)
+	dim_in = size(x)
+	IDFT{N,Complex{D},D,dims,typeof(A),typeof(At)}(dim_in,A,At)
 end
 
 #standard constructor
 IDFT(T::Type,dim_in::NTuple{N,Int},dims=1:N) where {N} = IDFT(zeros(T,dim_in),dims)
 
 function IDFT(x::AbstractArray{D,N},dims=1:ndims(x)) where {N,D<:Complex}
-	A,At = plan_ifft(x,dims), plan_fft(ifft(x,dims),dims)
-	IDFT{N,D,D,typeof(A),typeof(At)}(size(x),A,At)
+	y2 = zeros(D,size(x))
+	A = plan_ifft(x,dims)
+	At = plan_fft(y2,dims)
+	dim_in = size(x)
+	IDFT{N,D,D,dims,typeof(A),typeof(At)}(dim_in,A,At)
 end
 
 IDFT(dim_in::NTuple{N,Int},dims=1:N) where {N} = IDFT(zeros(dim_in),dims)
@@ -115,57 +129,57 @@ IDFT(T::Type,dim_in::Vararg{Int}) = IDFT(T,dim_in)
 # Mappings
 
 function mul!(y::AbstractArray{C,N},
-              L::DFT{N,C,C,T1,T2},
-              b::AbstractArray{C,N}) where {N,C<:Complex,T1,T2}
+              L::DFT{N,C,C,E,T1,T2},
+              b::AbstractArray{C,N}) where {N,C<:Complex,E,T1,T2}
 	mul!(y,L.A,b)
 end
 
 function mul!(y::AbstractArray{C,N},
-              L::DFT{N,C,D,T1,T2},
-              b::AbstractArray{D,N}) where {N,C<:Complex,D<:Real,T1,T2}
+              L::DFT{N,C,D,E,T1,T2},
+              b::AbstractArray{D,N}) where {N,C<:Complex,D<:Real,E,T1,T2}
 	mul!(y,L.A,complex(b))
 end
 
 function mul!(y::AbstractArray{C,N},
-              L::AdjointOperator{DFT{N,C,C,T1,T2}},
-              b::AbstractArray{C,N}) where {N,C<:Complex,T1,T2}
+              L::AdjointOperator{DFT{N,C,C,E,T1,T2}},
+              b::AbstractArray{C,N}) where {N,C<:Complex,E,T1,T2}
 	mul!(y,L.A.At,b)
 end
 
 function mul!(y::AbstractArray{D,N},
-              L::AdjointOperator{DFT{N,C,D,T1,T2}},
-              b::AbstractArray{C,N}) where {N,C<:Complex,D<:Real,T1,T2}
+              L::AdjointOperator{DFT{N,C,D,E,T1,T2}},
+              b::AbstractArray{C,N}) where {N,C<:Complex,D<:Real,E,T1,T2}
 	y2 = complex(y)
 	mul!(y2,L.A.At,b)
 	y .= real.(y2)
 end
 
 function mul!(y::AbstractArray{C,N},
-              L::IDFT{N,C,C,T1,T2},
-              b::AbstractArray{C,N}) where {N,C<:Complex,T1,T2}
+              L::IDFT{N,C,C,E,T1,T2},
+              b::AbstractArray{C,N}) where {N,C<:Complex,E,T1,T2}
 	mul!(y,L.A,b)
 end
 
 function mul!(y::AbstractArray{C,N},
-              L::IDFT{N,C,D,T1,T2},
-              b::AbstractArray{D,N}) where {N,C<:Complex,D<:Real,T1,T2}
+              L::IDFT{N,C,D,E,T1,T2},
+              b::AbstractArray{D,N}) where {N,C<:Complex,D<:Real,E,T1,T2}
 	mul!(y,L.A,complex(b))
 end
 
 function mul!(y::AbstractArray{C,N},
-              L::AdjointOperator{IDFT{N,C,C,T1,T2}},
-              b::AbstractArray{C,N}) where {N,C<:Complex,T1,T2}
+              L::AdjointOperator{IDFT{N,C,C,E,T1,T2}},
+              b::AbstractArray{C,N}) where {N,C<:Complex,E,T1,T2}
 	mul!(y,L.A.At,b)
-	y ./= length(b)
+	y ./= prod(size(b,e) for e in E)
 end
 
 function mul!(y::AbstractArray{D,N},
-              L::AdjointOperator{IDFT{N,C,D,T1,T2}},
-              b::AbstractArray{C,N}) where {N,C<:Complex,D<:Real,T1,T2}
+              L::AdjointOperator{IDFT{N,C,D,E,T1,T2}},
+              b::AbstractArray{C,N}) where {N,C<:Complex,D<:Real,E,T1,T2}
 
 	y2 = complex(y)
 	mul!(y2,L.A.At,b)
-	y .= (/).(real.(y2), length(b))
+	y .= (/).(real.(y2), prod(size(b,e) for e in E))
 end
 
 # Properties
@@ -175,8 +189,8 @@ size(L::FourierTransform) = (L.dim_in,L.dim_in)
 fun_name(A::DFT) = "ℱ"
 fun_name(A::IDFT) = "ℱ⁻¹"
 
-domainType(L::FourierTransform{N,C,D,T1,T2}) where {N,C,D,T1,T2} = D
-codomainType(L::FourierTransform{N,C,D,T1,T2}) where {N,C,D,T1,T2} = C
+domainType(L::FourierTransform{N,C,D,E,T1,T2}) where {N,C,D,E,T1,T2} = D
+codomainType(L::FourierTransform{N,C,D,E,T1,T2}) where {N,C,D,E,T1,T2} = C
 
 is_AcA_diagonal(L::FourierTransform)     = true
 is_AAc_diagonal(L::FourierTransform)     = true

--- a/test/test_linear_operators.jl
+++ b/test/test_linear_operators.jl
@@ -192,7 +192,6 @@ y1 = op*x1
 @test norm(op*(op'*y1) - diag_AAc(op)*y1) <= 1e-12
 
 ######### IDFT ############
-n = 4
 op = IDFT(Float64,(n,))
 x1 = randn(n)
 y1 = test_op(op, x1, fft(randn(n)), verb)
@@ -222,7 +221,20 @@ y2 = ifft(x1,1)
 
 @test all(norm.(y1 .- y2) .<= 1e-12)
 
-n = 4
+op = AbstractOperators.IDFT(Float64,(n,n))
+x1 = randn(n,n)
+y1 = test_op(op, x1, fft(randn(n,n)), verb)
+y2 = ifft(x1)
+
+@test all(norm.(y1 .- y2) .<= 1e-12)
+
+op = IDFT(Complex{Float64},(n,n))
+x1 = randn(n,n)+im*randn(n,n)
+y1 = test_op(op, x1, fft(randn(n,n)), verb)
+y2 = ifft(x1)
+
+@test all(norm.(y1 .- y2) .<= 1e-12)
+
 op = IDFT(Float64,(n,n),1)
 x1 = randn(n,n)
 y1 = test_op(op, x1, fft(randn(n,n)), verb)
@@ -237,6 +249,21 @@ y2 = ifft(x1,2)
 
 @test all(norm.(y1 .- y2) .<= 1e-12)
 
+n,m,l = 4,19,5
+op = IDFT(Complex{Float64},(n,m,l),2)
+x1 = fft(randn(n,m,l),2)
+y1 = test_op(op, x1, ifft(x1,2), verb)
+y2 = ifft(x1,2)
+
+@test all(norm.(y1 .- y2) .<= 1e-12)
+
+n,m,l = 4,18,5
+op = IDFT(Complex{Float64},(n,m,l),(1,2))
+x1 = fft(randn(n,m,l),(1,2))
+y1 = test_op(op, x1, ifft(x1,(1,2)), verb)
+y2 = ifft(x1,(1,2))
+
+@test all(norm.(y1 .- y2) .<= 1e-12)
 
 # other constructors
 op = IDFT((n,))

--- a/test/test_linear_operators.jl
+++ b/test/test_linear_operators.jl
@@ -96,7 +96,7 @@ x1 = randn(n,m)
 ######## DFT ############
 # seems like there is an object called DFT in Base julia 0.7 (however in 1.0 was rm)
 n = 4
-op = AbstractOperators.DFT(Float64,(n,)) 
+op = AbstractOperators.DFT(Float64,(n,))
 x1 = randn(n)
 y1 = test_op(op, x1, fft(randn(n)), verb)
 y2 = fft(x1)
@@ -107,6 +107,63 @@ op = AbstractOperators.DFT(Complex{Float64},(n,))
 x1 = randn(n)+im*randn(n)
 y1 = test_op(op, x1, fft(randn(n)), verb)
 y2 = fft(x1)
+
+@test all(norm.(y1 .- y2) .<= 1e-12)
+
+n = 4
+op = AbstractOperators.DFT(Float64,(n,))
+x1 = randn(n)
+y1 = test_op(op, x1, fft(randn(n)), verb)
+y2 = fft(x1)
+
+@test all(norm.(y1 .- y2) .<= 1e-12)
+
+op = AbstractOperators.DFT(Complex{Float64},(n,))
+x1 = randn(n)+im*randn(n)
+y1 = test_op(op, x1, fft(randn(n)), verb)
+y2 = fft(x1)
+
+@test all(norm.(y1 .- y2) .<= 1e-12)
+
+op = AbstractOperators.DFT(Float64,(n,),1)
+x1 = randn(n)
+y1 = test_op(op, x1, fft(randn(n)), verb)
+y2 = fft(x1,1)
+
+@test all(norm.(y1 .- y2) .<= 1e-12)
+
+op = AbstractOperators.DFT(Complex{Float64},(n,),1)
+x1 = randn(n)+im*randn(n)
+y1 = test_op(op, x1, fft(randn(n)), verb)
+y2 = fft(x1,1)
+
+@test all(norm.(y1 .- y2) .<= 1e-12)
+
+op = AbstractOperators.DFT(Float64,(n,n))
+x1 = randn(n,n)
+y1 = test_op(op, x1, fft(randn(n,n)), verb)
+y2 = fft(x1)
+
+@test all(norm.(y1 .- y2) .<= 1e-12)
+
+op = AbstractOperators.DFT(Complex{Float64},(n,n))
+x1 = randn(n,n)+im*randn(n,n)
+y1 = test_op(op, x1, fft(randn(n,n)), verb)
+y2 = fft(x1)
+
+@test all(norm.(y1 .- y2) .<= 1e-12)
+
+op = AbstractOperators.DFT(Float64,(n,n),1)
+x1 = randn(n,n)
+y1 = test_op(op, x1, fft(randn(n,n)), verb)
+y2 = fft(x1,1)
+
+@test all(norm.(y1 .- y2) .<= 1e-12)
+
+op = AbstractOperators.DFT(Complex{Float64},(n,n),2)
+x1 = randn(n,n)+im*randn(n,n)
+y1 = test_op(op, x1, fft(randn(n,n)), verb)
+y2 = fft(x1,2)
 
 @test all(norm.(y1 .- y2) .<= 1e-12)
 
@@ -149,6 +206,37 @@ y1 = test_op(op, x1, fft(randn(n)), verb)
 y2 = ifft(x1)
 
 @test all(norm.(y1 .- y2) .<= 1e-12)
+
+n = 4
+op = IDFT(Float64,(n,),1)
+x1 = randn(n)
+y1 = test_op(op, x1, fft(randn(n)), verb)
+y2 = ifft(x1,1)
+
+@test all(norm.(y1 .- y2) .<= 1e-12)
+
+op = IDFT(Complex{Float64},(n,),1)
+x1 = randn(n)+im*randn(n)
+y1 = test_op(op, x1, fft(randn(n)), verb)
+y2 = ifft(x1,1)
+
+@test all(norm.(y1 .- y2) .<= 1e-12)
+
+n = 4
+op = IDFT(Float64,(n,n),1)
+x1 = randn(n,n)
+y1 = test_op(op, x1, fft(randn(n,n)), verb)
+y2 = ifft(x1,1)
+
+@test all(norm.(y1 .- y2) .<= 1e-12)
+
+op = IDFT(Complex{Float64},(n,n),2)
+x1 = randn(n,n)+im*randn(n,n)
+y1 = test_op(op, x1, fft(randn(n,n)), verb)
+y2 = ifft(x1,2)
+
+@test all(norm.(y1 .- y2) .<= 1e-12)
+
 
 # other constructors
 op = IDFT((n,))
@@ -201,7 +289,7 @@ op = RDFT(n,n)
 @test is_eye(op)              == false
 @test is_diagonal(op)         == false
 @test is_AcA_diagonal(op)     == false
-@test is_AAc_diagonal(op)     == false 
+@test is_AAc_diagonal(op)     == false
 @test is_orthogonal(op)       == false
 @test is_invertible(op)       == true
 @test is_full_row_rank(op)    == true
@@ -257,7 +345,7 @@ op = IRDFT((10,),19)
 @test is_eye(op)              == false
 @test is_diagonal(op)         == false
 @test is_AcA_diagonal(op)     == false
-@test is_AAc_diagonal(op)     == false 
+@test is_AAc_diagonal(op)     == false
 @test is_orthogonal(op)       == false
 @test is_invertible(op)       == true
 @test is_full_row_rank(op)    == true
@@ -758,9 +846,9 @@ y1 = op*repeat(collect(range(0,stop=1,length=n)),1,m)
 @test all(norm.(y1[:,2] ) .<= 1e-12)
 
 Dx = spdiagm(0 => ones(n), -1 => -ones(n-1))
-Dx[1,1],Dx[1,2] = -1,1 
+Dx[1,1],Dx[1,2] = -1,1
 Dy = spdiagm(0 => ones(m), -1 => -ones(m-1))
-Dy[1,1],Dy[1,2] = -1,1 
+Dy[1,1],Dy[1,2] = -1,1
 
 Dxx = kron(sparse(I,m,m),Dx)
 Dyy = kron(Dy,sparse(I,n,n))

--- a/test/test_linear_operators.jl
+++ b/test/test_linear_operators.jl
@@ -95,7 +95,8 @@ x1 = randn(n,m)
 
 ######## DFT ############
 # seems like there is an object called DFT in Base julia 0.7 (however in 1.0 was rm)
-n = 4
+n,m = 4,7
+
 op = AbstractOperators.DFT(Float64,(n,))
 x1 = randn(n)
 y1 = test_op(op, x1, fft(randn(n)), verb)
@@ -110,7 +111,6 @@ y2 = fft(x1)
 
 @test all(norm.(y1 .- y2) .<= 1e-12)
 
-n = 4
 op = AbstractOperators.DFT(Float64,(n,))
 x1 = randn(n)
 y1 = test_op(op, x1, fft(randn(n)), verb)
@@ -139,30 +139,30 @@ y2 = fft(x1,1)
 
 @test all(norm.(y1 .- y2) .<= 1e-12)
 
-op = AbstractOperators.DFT(Float64,(n,n))
-x1 = randn(n,n)
-y1 = test_op(op, x1, fft(randn(n,n)), verb)
+op = AbstractOperators.DFT(Float64,(n,m))
+x1 = randn(n,m)
+y1 = test_op(op, x1, fft(randn(n,m)), verb)
 y2 = fft(x1)
 
 @test all(norm.(y1 .- y2) .<= 1e-12)
 
-op = AbstractOperators.DFT(Complex{Float64},(n,n))
-x1 = randn(n,n)+im*randn(n,n)
-y1 = test_op(op, x1, fft(randn(n,n)), verb)
+op = AbstractOperators.DFT(Complex{Float64},(n,m))
+x1 = randn(n,m)+im*randn(n,m)
+y1 = test_op(op, x1, fft(randn(n,m)), verb)
 y2 = fft(x1)
 
 @test all(norm.(y1 .- y2) .<= 1e-12)
 
-op = AbstractOperators.DFT(Float64,(n,n),1)
-x1 = randn(n,n)
-y1 = test_op(op, x1, fft(randn(n,n)), verb)
+op = AbstractOperators.DFT(Float64,(m,n),1)
+x1 = randn(m,n)
+y1 = test_op(op, x1, fft(randn(m,n)), verb)
 y2 = fft(x1,1)
 
 @test all(norm.(y1 .- y2) .<= 1e-12)
 
-op = AbstractOperators.DFT(Complex{Float64},(n,n),2)
-x1 = randn(n,n)+im*randn(n,n)
-y1 = test_op(op, x1, fft(randn(n,n)), verb)
+op = AbstractOperators.DFT(Complex{Float64},(n,m),2)
+x1 = randn(n,m)+im*randn(n,m)
+y1 = test_op(op, x1, fft(randn(n,m)), verb)
 y2 = fft(x1,2)
 
 @test all(norm.(y1 .- y2) .<= 1e-12)
@@ -192,6 +192,8 @@ y1 = op*x1
 @test norm(op*(op'*y1) - diag_AAc(op)*y1) <= 1e-12
 
 ######### IDFT ############
+n,m = 5,6
+
 op = IDFT(Float64,(n,))
 x1 = randn(n)
 y1 = test_op(op, x1, fft(randn(n)), verb)
@@ -206,7 +208,6 @@ y2 = ifft(x1)
 
 @test all(norm.(y1 .- y2) .<= 1e-12)
 
-n = 4
 op = IDFT(Float64,(n,),1)
 x1 = randn(n)
 y1 = test_op(op, x1, fft(randn(n)), verb)
@@ -221,30 +222,30 @@ y2 = ifft(x1,1)
 
 @test all(norm.(y1 .- y2) .<= 1e-12)
 
-op = AbstractOperators.IDFT(Float64,(n,n))
-x1 = randn(n,n)
-y1 = test_op(op, x1, fft(randn(n,n)), verb)
+op = AbstractOperators.IDFT(Float64,(n,m))
+x1 = randn(n,m)
+y1 = test_op(op, x1, fft(randn(n,m)), verb)
 y2 = ifft(x1)
 
 @test all(norm.(y1 .- y2) .<= 1e-12)
 
-op = IDFT(Complex{Float64},(n,n))
-x1 = randn(n,n)+im*randn(n,n)
-y1 = test_op(op, x1, fft(randn(n,n)), verb)
+op = IDFT(Complex{Float64},(n,m))
+x1 = randn(n,m)+im*randn(n,m)
+y1 = test_op(op, x1, fft(randn(n,m)), verb)
 y2 = ifft(x1)
 
 @test all(norm.(y1 .- y2) .<= 1e-12)
 
-op = IDFT(Float64,(n,n),1)
-x1 = randn(n,n)
-y1 = test_op(op, x1, fft(randn(n,n)), verb)
+op = IDFT(Float64,(m,n),1)
+x1 = randn(m,n)
+y1 = test_op(op, x1, fft(randn(m,n)), verb)
 y2 = ifft(x1,1)
 
 @test all(norm.(y1 .- y2) .<= 1e-12)
 
-op = IDFT(Complex{Float64},(n,n),2)
-x1 = randn(n,n)+im*randn(n,n)
-y1 = test_op(op, x1, fft(randn(n,n)), verb)
+op = IDFT(Complex{Float64},(m,n),2)
+x1 = randn(m,n)+im*randn(m,n)
+y1 = test_op(op, x1, fft(randn(m,n)), verb)
 y2 = ifft(x1,2)
 
 @test all(norm.(y1 .- y2) .<= 1e-12)
@@ -262,6 +263,13 @@ op = IDFT(Complex{Float64},(n,m,l),(1,2))
 x1 = fft(randn(n,m,l),(1,2))
 y1 = test_op(op, x1, ifft(x1,(1,2)), verb)
 y2 = ifft(x1,(1,2))
+
+@test all(norm.(y1 .- y2) .<= 1e-12)
+
+op = IDFT(Complex{Float64},(n,m,l),(3,2))
+x1 = fft(randn(n,m,l),(3,2))
+y1 = test_op(op, x1, ifft(x1,(3,2)), verb)
+y2 = ifft(x1,(3,2))
 
 @test all(norm.(y1 .- y2) .<= 1e-12)
 


### PR DESCRIPTION
This is adding an optional argument `dims` to `DFT`/`IDFT`. Discussed in #12 

Follows the definition from AbstractFFTs: https://github.com/JuliaMath/AbstractFFTs.jl/blob/2f11b0e86c7b1c1660f7513849986e85f58a28b7/src/definitions.jl#L198 
by adding `dims=1:ndims(x)` or `dims=1:N` to functions and constructors: 
`DFT(x::AbstractArray{D,N},dims=1:ndims(x)) where {N,D<:Real}` or
`DFT(dim_in::NTuple{N,Int},dims=1:N) where {N} = DFT(zeros(dim_in),dims)`
 
I hope I caught all cases and methods but please review and let me know if I'm missing anything.