### PR TITLE
Replace Julia version 1.6 with 1.10 in CI.yaml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         version:
           - '1'
-          - '1.6'
+          - '1.10'
         os:
           - ubuntu-latest
           - macOS-latest


### PR DESCRIPTION
Julia version 1.10 has replaced 1.6 as the LTS version