### PR TITLE
Fine tune opnorm and estimate_opnorm parameters & standardize the tolerance their tests

### DIFF
--- a/src/AbstractOperators.jl
+++ b/src/AbstractOperators.jl
@@ -12,7 +12,7 @@ abstract type LinearOperator <: AbstractOperator end
 abstract type NonLinearOperator <: AbstractOperator end
 
 import LinearAlgebra: mul!
-import Base: size, ndims, AbstractLock, @lock
+import Base: size, ndims, @lock
 import Base.Threads: @spawn, @threads, nthreads
 
 import OperatorCore: 

--- a/src/batching/SpreadingBatchOp.jl
+++ b/src/batching/SpreadingBatchOp.jl
@@ -43,7 +43,7 @@ struct SpreadingBatchOpLocking{dT,cT,dM,cM,sD,N,M,opT} <: SpreadingBatchOp{dT,cT
 	domain_size::NTuple{N,Int}
 	codomain_size::NTuple{M,Int}
 	batch_indices::CartesianIndices
-	locks::Array{AbstractLock}
+	locks::Array{Base.AbstractLock}
 end
 
 struct SpreadingBatchOpFixedOperator{dT,cT,dM,cM,sD,N,M,opT} <:
@@ -348,7 +348,7 @@ function create_threaded_SpreadingBatchOp(
 			)
 		elseif threading_strategy == ThreadingStrategy.LOCKING
 			d = Dict{eltype(operators),Int}()
-			locks = Array{AbstractLock}(undef, size(operators))
+			locks = Array{Base.AbstractLock}(undef, size(operators))
 			for i in eachindex(operators)
 				if haskey(d, operators[i])
 					locks[i] = locks[d[operators[i]]]

--- a/src/calculus/Ax_mul_Bx.jl
+++ b/src/calculus/Ax_mul_Bx.jl
@@ -95,7 +95,6 @@ domain_type(L::Union{Ax_mul_Bx,Ax_mul_BxJac}) = domain_type(L.A)
 codomain_type(L::Union{Ax_mul_Bx,Ax_mul_BxJac}) = codomain_type(L.A)
 domain_storage_type(L::Union{Ax_mul_Bx,Ax_mul_BxJac}) = domain_storage_type(L.A)
 codomain_storage_type(L::Union{Ax_mul_Bx,Ax_mul_BxJac}) = codomain_storage_type(L.B)
-is_thread_safe(L::Union{Ax_mul_Bx,Ax_mul_BxJac}) = false
 
 # utils
 function permute(

--- a/src/calculus/Ax_mul_Bxt.jl
+++ b/src/calculus/Ax_mul_Bxt.jl
@@ -106,7 +106,6 @@ domain_type(L::Union{Ax_mul_Bxt,Ax_mul_BxtJac}) = domain_type(L.A)
 codomain_type(L::Union{Ax_mul_Bxt,Ax_mul_BxtJac}) = codomain_type(L.A)
 domain_storage_type(L::Union{Ax_mul_Bxt,Ax_mul_BxtJac}) = domain_storage_type(L.A)
 codomain_storage_type(L::Union{Ax_mul_Bxt,Ax_mul_BxtJac}) = codomain_storage_type(L.B)
-is_thread_safe(L::Union{Ax_mul_Bxt,Ax_mul_BxtJac}) = false
 
 # utils
 function permute(

--- a/src/calculus/BroadCast.jl
+++ b/src/calculus/BroadCast.jl
@@ -31,7 +31,7 @@ struct OperatorBroadCast{T,N,M,Threaded,Compact,Imask,L,C,D,K} <: AbstractBroadC
 		T = codomain_type(A)
 		dim_in = size(A, 1)
 		Imask = Tuple(d ≤ N && (dim_out[d] == dim_in[d]) for d in 1:M)
-		broadcast_dims = Tuple(Imask[d] ? 1 : dim_out[d] for d in 1:length(dim_out))
+		broadcast_dims = Tuple(Imask[d] ? 1 : dim_out[d] for d in eachindex(dim_out))
 		idxs = CartesianIndices(broadcast_dims)
 		compact = all(Imask[1:N])
 		bufC = allocate_in_codomain(A)
@@ -220,8 +220,8 @@ function remove_displacement(R::OperatorBroadCast{T,N,M,true,Imask}) where {T,N,
 end
 
 has_fast_opnorm(::NoOperatorBroadCast) = true
-has_fast_opnorm(::OperatorBroadCast{T,N,M,false}) where {T,N,M} = has_fast_opnorm(R.A)
-has_fast_opnorm(::OperatorBroadCast{T,N,M,true}) where {T,N,M} = has_fast_opnorm(R.A[1])
+has_fast_opnorm(R::OperatorBroadCast{T,N,M,false}) where {T,N,M} = has_fast_opnorm(R.A)
+has_fast_opnorm(R::OperatorBroadCast{T,N,M,true}) where {T,N,M} = has_fast_opnorm(R.A[1])
 function LinearAlgebra.opnorm(R::NoOperatorBroadCast{T,N,M}) where {T,N,M}
 	real(T)(sqrt(prod(R.dim_out[d] for d in 1:M if R.dim_out[d] != R.reshaped_dim_in[d])))
 end

--- a/src/calculus/BroadCast.jl
+++ b/src/calculus/BroadCast.jl
@@ -234,7 +234,7 @@ function permute(R::OperatorBroadCast{T,N,M,false}, p::AbstractVector{Int}) wher
 	return BroadCast(permute(R.A, p), R.dim_out; threaded=false)
 end
 function permute(R::OperatorBroadCast{T,N,M,true}, p::AbstractVector{Int}) where {T,N,M}
-	return BroadCast([permute(A, p) for A in R.A], R.dim_out; threaded=true)
+	return BroadCast(permute(R.A[1], p), R.dim_out; threaded=true)
 end
 
 @generated function get_input_slice(

--- a/src/calculus/Compose.jl
+++ b/src/calculus/Compose.jl
@@ -241,7 +241,6 @@ domain_type(L::Compose) = domain_type(L.A[1])
 codomain_type(L::Compose) = codomain_type(L.A[end])
 domain_storage_type(L::Compose) = domain_storage_type(L.A[1])
 codomain_storage_type(L::Compose) = codomain_storage_type(L.A[end])
-is_thread_safe(::Compose) = false
 
 is_linear(L::Compose) = all(is_linear.(L.A))
 function is_diagonal(L::Compose)

--- a/src/calculus/DCAT.jl
+++ b/src/calculus/DCAT.jl
@@ -226,6 +226,6 @@ diag(L::DCAT{N,Tuple{E,Vararg{E,M}}}) where {N,M,E<:Eye} = 1.0
 diag_AAc(L::DCAT{N,Tuple{E,Vararg{E,M}}}) where {N,M,E<:Eye} = 1.0
 diag_AcA(L::DCAT{N,Tuple{E,Vararg{E,M}}}) where {N,M,E<:Eye} = 1.0
 
-has_fast_opnorm(::DCAT) = all(has_fast_opnorm.(L.A))
+has_fast_opnorm(L::DCAT) = all(has_fast_opnorm.(L.A))
 LinearAlgebra.opnorm(L::DCAT) = maximum(opnorm.(L.A))
 estimate_opnorm(L::DCAT) = maximum(estimate_opnorm.(L.A))

--- a/src/calculus/HadamardProd.jl
+++ b/src/calculus/HadamardProd.jl
@@ -92,7 +92,6 @@ domain_type(L::Union{HadamardProd,HadamardProdJac}) = domain_type(L.A)
 codomain_type(L::Union{HadamardProd,HadamardProdJac}) = codomain_type(L.A)
 domain_storage_type(L::Union{HadamardProd,HadamardProdJac}) = domain_storage_type(L.A)
 codomain_storage_type(L::Union{HadamardProd,HadamardProdJac}) = codomain_storage_type(L.A)
-is_thread_safe(::HadamardProd) = false
 
 # utils
 function permute(

--- a/src/calculus/Jacobian.jl
+++ b/src/calculus/Jacobian.jl
@@ -111,4 +111,3 @@ domain_type(L::Jacobian) = domain_type(L.A)
 codomain_type(L::Jacobian) = codomain_type(L.A)
 domain_storage_type(L::Jacobian) = domain_storage_type(L.A)
 codomain_storage_type(L::Jacobian) = codomain_storage_type(L.A)
-is_thread_safe(::Jacobian) = false

--- a/src/calculus/Scale.jl
+++ b/src/calculus/Scale.jl
@@ -129,7 +129,7 @@ diag_AcA(L::Scale) = (L.coeff)^2 * diag_AcA(L.A)
 diag_AAc(L::Scale) = (L.coeff)^2 * diag_AAc(L.A)
 remove_displacement(S::Scale) = Scale(S.coeff, S.coeff_conj, remove_displacement(S.A))
 
-has_fast_opnorm(::Scale) = has_fast_opnorm(L.A)
+has_fast_opnorm(L::Scale) = has_fast_opnorm(L.A)
 LinearAlgebra.opnorm(L::Scale) = abs(L.coeff) * LinearAlgebra.opnorm(L.A)
 estimate_opnorm(L::Scale) = abs(L.coeff) * estimate_opnorm(L.A)
 

--- a/src/calculus/Sum.jl
+++ b/src/calculus/Sum.jl
@@ -107,7 +107,6 @@ domain_storage_type(S::Sum{K,C,D,L}) where {K,C<:AbstractArray,D,L} = domain_sto
 domain_storage_type(S::Sum{K,C,D,L}) where {K,C<:Tuple,D,L} = domain_storage_type.(Ref(S.A[1]))
 codomain_storage_type(S::Sum{K,C,D,L}) where {K,C<:AbstractArray,D,L} = codomain_storage_type(S.A[1])
 codomain_storage_type(S::Sum{K,C,D,L}) where {K,C<:Tuple,D,L} = codomain_storage_type.(Ref(S.A[1]))
-is_thread_safe(::Sum) = false
 
 fun_domain(S::Sum) = fun_domain(S.A[1])
 fun_codomain(S::Sum) = fun_codomain(S.A[1])

--- a/src/calculus/VCAT.jl
+++ b/src/calculus/VCAT.jl
@@ -190,7 +190,6 @@ function codomain_storage_type(H::VCAT)
 	T = promote_type(codomain_type(H)...)
 	return ArrayPartition{T, Tuple{codomain...}}
 end
-is_thread_safe(::VCAT) = false
 
 is_linear(L::VCAT) = all(is_linear.(L.A))
 is_AcA_diagonal(L::VCAT) = all(is_AcA_diagonal.(L.A))

--- a/src/linearoperators/MatrixOp.jl
+++ b/src/linearoperators/MatrixOp.jl
@@ -143,4 +143,5 @@ is_positive_semidefinite(L::MatrixOp) = issymmetric(L.A) && all(eigvals(Symmetri
 has_optimized_normalop(::MatrixOp) = true
 get_normal_op(L::MatrixOp) = MatrixOp(domain_type(L), size(L, 2), L.A' * L.A)
 
+has_fast_opnorm(::MatrixOp) = true
 LinearAlgebra.opnorm(L::MatrixOp) = opnorm(L.A)

--- a/src/properties.jl
+++ b/src/properties.jl
@@ -388,8 +388,8 @@ It is computed using the power method by default, unless the operator has a fast
 The operator norm is defined as: `‖A‖ = sup_{x != 0} ‖A*x‖ / ‖x‖`.
 
 Parameters of power iteration:
-- Maximum number of iterations: 100
-- Tolerance for convergence: 1e-8
+- Maximum number of iterations: 1000
+- Tolerance for convergence: sqrt(eps(real(codomain_type(A))))*10
 These parameters can be adjusted in the [estimate_opnorm](@ref) function.
 """
 function LinearAlgebra.opnorm(A::AbstractOperator)
@@ -408,13 +408,13 @@ The operator norm is defined as: `‖A‖ = sup_{x != 0} ‖A*x‖ / ‖x‖`.
 
 Parameters of power iteration:
 - Maximum number of iterations: 20
-- Tolerance for convergence: 1e-4
+- Tolerance for convergence: sqrt(eps(real(codomain_type(A))))
 These parameters can be adjusted by passing `maxit` and `tol` keyword arguments. E.g.:
 ```julia
 julia> estimate_opnorm(A; maxit=50, tol=1e-6)
 ```
 """
-function estimate_opnorm(A::AbstractOperator; maxit=50, tol=eps(real(codomain_type(A)))*100)
+function estimate_opnorm(A::AbstractOperator; maxit=20, tol=sqrt(eps(real(codomain_type(A)))))
 	if has_fast_opnorm(A)
 		return opnorm(A)
 	else
@@ -422,7 +422,7 @@ function estimate_opnorm(A::AbstractOperator; maxit=50, tol=eps(real(codomain_ty
 	end
 end
 
-function powerit(A::AbstractOperator; maxit=200, tol=eps(real(codomain_type(A)))*100)
+function powerit(A::AbstractOperator; maxit=1000, tol=eps(real(codomain_type(A))))
 	# Power method for estimating the operator norm
 	AHA = A' * A
     x = allocate_in_domain(A)
@@ -435,7 +435,7 @@ function powerit(A::AbstractOperator; maxit=200, tol=eps(real(codomain_type(A)))
     for _ in 1:maxit
         mul!(y, AHA, x)
         λ = norm(y)
-        if abs(λ - λ_old) < tol^2
+        if abs(λ - λ_old) < tol
             break
         end
         λ_old = λ

--- a/src/properties.jl
+++ b/src/properties.jl
@@ -388,8 +388,8 @@ It is computed using the power method by default, unless the operator has a fast
 The operator norm is defined as: `‖A‖ = sup_{x != 0} ‖A*x‖ / ‖x‖`.
 
 Parameters of power iteration:
-- Maximum number of iterations: 1000
-- Tolerance for convergence: sqrt(eps(real(codomain_type(A))))*10
+- Maximum number of iterations: 100
+- Tolerance for convergence: 1e-6
 These parameters can be adjusted in the [estimate_opnorm](@ref) function.
 """
 function LinearAlgebra.opnorm(A::AbstractOperator)
@@ -408,13 +408,13 @@ The operator norm is defined as: `‖A‖ = sup_{x != 0} ‖A*x‖ / ‖x‖`.
 
 Parameters of power iteration:
 - Maximum number of iterations: 20
-- Tolerance for convergence: sqrt(eps(real(codomain_type(A))))
+- Tolerance for convergence: 0.01
 These parameters can be adjusted by passing `maxit` and `tol` keyword arguments. E.g.:
 ```julia
 julia> estimate_opnorm(A; maxit=50, tol=1e-6)
 ```
 """
-function estimate_opnorm(A::AbstractOperator; maxit=20, tol=sqrt(eps(real(codomain_type(A)))))
+function estimate_opnorm(A::AbstractOperator; maxit=20, tol=1e-3)
 	if has_fast_opnorm(A)
 		return opnorm(A)
 	else
@@ -422,12 +422,12 @@ function estimate_opnorm(A::AbstractOperator; maxit=20, tol=sqrt(eps(real(codoma
 	end
 end
 
-function powerit(A::AbstractOperator; maxit=1000, tol=eps(real(codomain_type(A))))
+function powerit(A::AbstractOperator; maxit=100, tol=1e-6)
 	# Power method for estimating the operator norm
 	AHA = A' * A
     x = allocate_in_domain(A)
 	y = similar(x)
-	Random.rand!(x)
+	Random.randn!(x)
     normalize!(x)
     λ = zero(real(eltype(x)))
     λ_old = real(eltype(x))(Inf)
@@ -435,7 +435,7 @@ function powerit(A::AbstractOperator; maxit=1000, tol=eps(real(codomain_type(A))
     for _ in 1:maxit
         mul!(y, AHA, x)
         λ = norm(y)
-        if abs(λ - λ_old) < tol
+        if abs(λ - λ_old) < max(tol * λ, tol)
             break
         end
         λ_old = λ

--- a/src/properties.jl
+++ b/src/properties.jl
@@ -377,7 +377,7 @@ Returns the diagonal of `A`. If `A` is not diagonal, an error is thrown.
 
 The diagonal is defined as the vector `d` such that `A * x = d .* x` for all `x` in the domain of `A`, where `.*` is the element-wise multiplication.
 """
-LinearAlgebra.diag(::AbstractOperator) = error("cannot get diagonal of operator of type $(typeof(L))")
+LinearAlgebra.diag(L::AbstractOperator) = error("cannot get diagonal of operator of type $(typeof(L))")
 
 """
 	LinearAlgebra.opnorm(A::AbstractOperator)

--- a/test/batching/test_SimpleBatchOp.jl
+++ b/test/batching/test_SimpleBatchOp.jl
@@ -4,6 +4,7 @@ end
 if !isdefined(Main, :test_op)
     include("../utils.jl")
 end
+Random.seed!(0)
 using BenchmarkTools
 
 function test_simple_batchop(op, batch_op, x, y, z, threaded)

--- a/test/batching/test_SimpleBatchOp.jl
+++ b/test/batching/test_SimpleBatchOp.jl
@@ -102,6 +102,7 @@ function other_tests(threaded)
 	n_op = AbstractOperators.get_normal_op(batch_op)
 	@test typeof(n_op) <: typeof(batch_op)
 	# opnorm, estimate_opnorm -- exact solution is expected for both
+	@test AbstractOperators.has_fast_opnorm(batch_op) == AbstractOperators.has_fast_opnorm(op)
 	@test opnorm(batch_op) == opnorm(op)
 	@test estimate_opnorm(batch_op) == estimate_opnorm(op)
 	@test estimate_opnorm(batch_op) == opnorm(batch_op)

--- a/test/batching/test_SimpleBatchOp.jl
+++ b/test/batching/test_SimpleBatchOp.jl
@@ -100,9 +100,10 @@ function other_tests(threaded)
 	@test AbstractOperators.has_optimized_normalop(batch_op) == AbstractOperators.has_optimized_normalop(op)
 	n_op = AbstractOperators.get_normal_op(batch_op)
 	@test typeof(n_op) <: typeof(batch_op)
-	# opnorm, estimate_opnorm
-	@test opnorm(batch_op) ≈ opnorm(op)
+	# opnorm, estimate_opnorm -- exact solution is expected for both
+	@test opnorm(batch_op) == opnorm(op)
 	@test estimate_opnorm(batch_op) == estimate_opnorm(op)
+	@test estimate_opnorm(batch_op) == opnorm(batch_op)
 	# diag, diag_AcA, diag_AAc
 	@test diag(batch_op) == [diag(op)'; diag(op)']'
 	@test diag_AcA(batch_op) == [diag_AcA(op)'; diag_AcA(op)']'

--- a/test/batching/test_SpreadingBatchOp.jl
+++ b/test/batching/test_SpreadingBatchOp.jl
@@ -4,6 +4,7 @@ end
 if !isdefined(Main, :test_op)
     include("../utils.jl")
 end
+Random.seed!(0)
 using BenchmarkTools
 
 function test_spreading_batchop(operators, batch_op, x, y, z, threaded)

--- a/test/batching/test_SpreadingBatchOp.jl
+++ b/test/batching/test_SpreadingBatchOp.jl
@@ -110,9 +110,10 @@ function other_spreadingbatchop_tests(threaded)
 	@test AbstractOperators.has_optimized_normalop(bop) == AbstractOperators.has_optimized_normalop(ops[1])
 	nbop = AbstractOperators.get_normal_op(bop)
 	@test size(nbop, 1) == size(bop, 1) && size(nbop, 2) == size(bop, 2)
-	# opnorm / estimate_opnorm aggregate as maximum
+	# opnorm / estimate_opnorm aggregate as maximum -- exact solution is expected for both
 	@test opnorm(bop) == maximum(opnorm.(ops))
 	@test estimate_opnorm(bop) == maximum(estimate_opnorm.(ops))
+	@test estimate_opnorm(bop) == opnorm(bop)
 	# diag family collapses to first operator entries (identical)
 	@test diag(bop) == repeat(diag(ops[1]), outer=(1,3,4))
 	@test diag_AcA(bop) == repeat(diag_AcA(ops[1]), outer=(1,3,4))
@@ -232,8 +233,9 @@ end
 			@test AbstractOperators.has_optimized_normalop(bop) == AbstractOperators.has_optimized_normalop(ops[1])
 			
 			# opnorm methods for Copying (use approximate equality for floating point)
-			@test opnorm(bop) ≈ maximum(opnorm.(ops))
-			@test estimate_opnorm(bop) ≈ maximum(estimate_opnorm.(ops)) atol=1e-4
+			operator_norm = opnorm(bop)
+			@test operator_norm ≈ maximum(opnorm.(ops))
+			@test estimate_opnorm(bop) ≈ operator_norm rtol=0.05
 			
 			# diag methods for Copying - use operators with diag
 			ops2 = [DiagOp(rand(5)) for i in 1:3]

--- a/test/batching/test_SpreadingBatchOp.jl
+++ b/test/batching/test_SpreadingBatchOp.jl
@@ -234,6 +234,7 @@ end
 			@test AbstractOperators.has_optimized_normalop(bop) == AbstractOperators.has_optimized_normalop(ops[1])
 			
 			# opnorm methods for Copying (use approximate equality for floating point)
+			@test AbstractOperators.has_fast_opnorm(bop) == AbstractOperators.has_fast_opnorm(ops[1])
 			operator_norm = opnorm(bop)
 			@test operator_norm ≈ maximum(opnorm.(ops)) rtol=5e-6
 			@test estimate_opnorm(bop) ≈ operator_norm rtol=0.05

--- a/test/batching/test_SpreadingBatchOp.jl
+++ b/test/batching/test_SpreadingBatchOp.jl
@@ -234,7 +234,7 @@ end
 			
 			# opnorm methods for Copying (use approximate equality for floating point)
 			operator_norm = opnorm(bop)
-			@test operator_norm ≈ maximum(opnorm.(ops))
+			@test operator_norm ≈ maximum(opnorm.(ops)) rtol=5e-6
 			@test estimate_opnorm(bop) ≈ operator_norm rtol=0.05
 			
 			# diag methods for Copying - use operators with diag

--- a/test/calculus/test_Ax_mul_Bx.jl
+++ b/test/calculus/test_Ax_mul_Bx.jl
@@ -4,6 +4,7 @@ end
 if !isdefined(Main, :test_op)
     include("../utils.jl")
 end
+Random.seed!(0)
 
 @testset "Ax_mul_Bx" begin
     verb && println(" --- Testing Ax_mul_Bx --- ")

--- a/test/calculus/test_Ax_mul_Bx.jl
+++ b/test/calculus/test_Ax_mul_Bx.jl
@@ -100,4 +100,10 @@ Random.seed!(0)
     r = randn(k, l)
     y, grad = test_NLop(P2, x, r, verb)
     @test norm((C * x) * ((A * x)' * (B * x))' - y) < 1e-8
+
+    # test equality
+    n, l = 2, 3
+    A, B = MatrixOp(randn(l, n), l), MatrixOp(randn(l, n), l)
+    @test Ax_mul_Bx(A, B) == Ax_mul_Bx(A, B)
+    @test Jacobian(Ax_mul_Bx(A, B), x) == Jacobian(Ax_mul_Bx(A, B), x)
 end

--- a/test/calculus/test_Ax_mul_Bxt.jl
+++ b/test/calculus/test_Ax_mul_Bxt.jl
@@ -4,6 +4,7 @@ end
 if !isdefined(Main, :test_op)
     include("../utils.jl")
 end
+Random.seed!(0)
 
 @testset "Ax_mul_Bxt" begin
     verb && println(" --- Testing Ax_mul_Bxt --- ")

--- a/test/calculus/test_Ax_mul_Bxt.jl
+++ b/test/calculus/test_Ax_mul_Bxt.jl
@@ -68,4 +68,10 @@ Random.seed!(0)
 
     @test_throws Exception Ax_mul_Bxt(Eye(2, 2), Eye(2, 1))
     @test_throws Exception Ax_mul_Bxt(Eye(2, 2, 2), Eye(2, 2, 2))
+
+    # test equality
+    n, m = 3, 4
+    A, B = MatrixOp(randn(n, m)), MatrixOp(randn(n, m))
+    @test Ax_mul_Bxt(A, B) == Ax_mul_Bxt(A, B)
+    @test Jacobian(Ax_mul_Bxt(A, B), x) == Jacobian(Ax_mul_Bxt(A, B), x)
 end

--- a/test/calculus/test_Axt_mul_Bx.jl
+++ b/test/calculus/test_Axt_mul_Bx.jl
@@ -4,6 +4,7 @@ end
 if !isdefined(Main, :test_op)
     include("../utils.jl")
 end
+Random.seed!(0)
 
 @testset "Axt_mul_Bx" begin
     verb && println(" --- Testing Axt_mul_Bx --- ")

--- a/test/calculus/test_Axt_mul_Bx.jl
+++ b/test/calculus/test_Axt_mul_Bx.jl
@@ -70,4 +70,10 @@ Random.seed!(0)
 
     @test_throws Exception Axt_mul_Bx(Eye(2, 2), Eye(2, 1))
     @test_throws Exception Axt_mul_Bx(Eye(2, 2, 2), Eye(2, 2, 2))
+
+    # test equality
+    n, m = 3, 4
+    A, B = MatrixOp(randn(n, m)), MatrixOp(randn(n, m))
+    @test Axt_mul_Bx(A, B) == Axt_mul_Bx(A, B)
+    @test Jacobian(Axt_mul_Bx(A, B), x) == Jacobian(Axt_mul_Bx(A, B), x)
 end

--- a/test/calculus/test_adjointoperator.jl
+++ b/test/calculus/test_adjointoperator.jl
@@ -73,7 +73,7 @@ end
 
     # opnorm / estimate consistency (underlying matrix op)
     opnorm_opT = opnorm(opT)
-    @test opnorm_opT ≈ opnorm(opA1)
+    @test opnorm_opT ≈ opnorm(opA1) rtol=5e-6
     @test estimate_opnorm(opT) ≈ estimate_opnorm(opA1) rtol=0.05
     @test opnorm_opT ≈ estimate_opnorm(opT) rtol=0.05
 

--- a/test/calculus/test_adjointoperator.jl
+++ b/test/calculus/test_adjointoperator.jl
@@ -4,6 +4,7 @@ end
 if !isdefined(Main, :test_op)
     include("../utils.jl")
 end
+Random.seed!(0)
 
 @testset "AdjointOperator" begin
     verb && println(" --- Testing AdjointOperator --- ")

--- a/test/calculus/test_adjointoperator.jl
+++ b/test/calculus/test_adjointoperator.jl
@@ -73,6 +73,7 @@ Random.seed!(0)
     @test size(opT) == ((n,), (m,))
 
     # opnorm / estimate consistency (underlying matrix op)
+    @test AbstractOperators.has_fast_opnorm(opT) == AbstractOperators.has_fast_opnorm(opA1)
     opnorm_opT = opnorm(opT)
     @test opnorm_opT ≈ opnorm(opA1) rtol=5e-6
     @test estimate_opnorm(opT) ≈ estimate_opnorm(opA1) rtol=0.05
@@ -91,4 +92,6 @@ Random.seed!(0)
     show(io2, opT)
     str2 = String(take!(io2))
     @test occursin("ᵃ", str2)
+
+    @test opA1' == opA1'
 end

--- a/test/calculus/test_adjointoperator.jl
+++ b/test/calculus/test_adjointoperator.jl
@@ -70,8 +70,8 @@ end
     # opnorm / estimate consistency (underlying matrix op)
     opnorm_opT = opnorm(opT)
     @test opnorm_opT ≈ opnorm(opA1)
-    @test abs(estimate_opnorm(opT) - estimate_opnorm(opA1)) / opnorm_opT < 0.03
-    @test abs(opnorm_opT - estimate_opnorm(opT)) / opnorm_opT < 0.03
+    @test estimate_opnorm(opT) ≈ estimate_opnorm(opA1) rtol=0.05
+    @test opnorm_opT ≈ estimate_opnorm(opT) rtol=0.05
 
     # For a diagonal operator, test diag_AcA matches original's diag_AAc
     d2 = randn(5)

--- a/test/calculus/test_adjointoperator.jl
+++ b/test/calculus/test_adjointoperator.jl
@@ -9,7 +9,11 @@ end
     verb && println(" --- Testing AdjointOperator --- ")
 
     m, n = 5, 7
-    A1 = randn(m, n)
+    A1 =
+        rand(m) * rand(n)' * 3.0 +
+        rand(m) * rand(n)' * 2.0 +
+        rand(m) * rand(n)' * 1.0 +
+        0.01 * rand(m, n) # make it approximately rank 3
     opA1 = MatrixOp(A1)
     opA1t = MatrixOp(A1')
     opT = AdjointOperator(opA1)
@@ -50,7 +54,7 @@ end
 
     # Error on nonlinear operator
     struct DummyNonlinearOp <: AbstractOperator end
-    Base.size(::DummyNonlinearOp) = (2,2)
+    Base.size(::DummyNonlinearOp) = (2, 2)
     AbstractOperators.is_linear(::DummyNonlinearOp) = false
     @test_throws ErrorException AdjointOperator(DummyNonlinearOp())
 
@@ -82,5 +86,8 @@ end
     @test diag_AAc(AD) == diag_AcA(D)
 
     # fun_name pattern (indirect via show)
-    io2 = IOBuffer(); show(io2, opT); str2 = String(take!(io2)); @test occursin("ᵃ", str2)
+    io2 = IOBuffer()
+    show(io2, opT)
+    str2 = String(take!(io2))
+    @test occursin("ᵃ", str2)
 end

--- a/test/calculus/test_affineadd.jl
+++ b/test/calculus/test_affineadd.jl
@@ -4,6 +4,7 @@ end
 if !isdefined(Main, :test_op)
     include("../utils.jl")
 end
+Random.seed!(0)
 
 @testset "AffineAdd" begin
     verb && println(" --- Testing AffineAdd --- ")

--- a/test/calculus/test_broadcast.jl
+++ b/test/calculus/test_broadcast.jl
@@ -4,6 +4,7 @@ end
 if !isdefined(Main, :test_op)
     include("../utils.jl")
 end
+Random.seed!(0)
 
 @testset "BroadCast" begin
     verb && println(" --- Testing BroadCast --- ")

--- a/test/calculus/test_broadcast.jl
+++ b/test/calculus/test_broadcast.jl
@@ -284,11 +284,11 @@ end
         # opnorm for OperatorBroadCast
         A_op = MatrixOp(randn(3, 2))
         B_op = BroadCast(A_op, (3, 4); threaded=false)
-        @test opnorm(B_op) == opnorm(A_op)
+        @test opnorm(B_op) ≈ opnorm(A_op)
         
         if Threads.nthreads() > 1
             B_op_t = BroadCast(A_op, (3, 4); threaded=true)
-            @test opnorm(B_op_t) == opnorm(A_op)
+            @test opnorm(B_op_t) ≈ opnorm(A_op)
         end
     end
 

--- a/test/calculus/test_broadcast.jl
+++ b/test/calculus/test_broadcast.jl
@@ -20,6 +20,7 @@ Random.seed!(0)
         y2 = zeros(dim_out)
         y2 .= A1 * x1
         @test norm(y1 - y2) <= 1e-12
+        @test AbstractOperators.has_fast_opnorm(opR) == AbstractOperators.has_fast_opnorm(opA1)
 
         m, n, l, k = 8, 4, 5, 7
         dim_out = (m, n, l, k)
@@ -137,20 +138,22 @@ Random.seed!(0)
     @test remove_displacement(rd) == rd  # idempotent
 
     # permute test (domain permutation) using HCAT to create partition domain
-    A1 = HCAT(Eye(m), Eye(m))  # domain is ArrayPartition
-    B1 = BroadCast(A1, (m, 2); threaded=false)
-    xpart = ArrayPartition(randn(m), randn(m))
-    y_base = B1 * xpart
-    p = [2,1]
-    B1p = AbstractOperators.permute(B1, p)
-    xpart_p = ArrayPartition(xpart.x[p]...)
-    y_perm = B1p * xpart_p
-    @test y_perm == y_base  # same broadcasted sum after permutation inversion
+    for threaded in [false, true]
+        A1 = HCAT(Eye(m), Eye(m))  # domain is ArrayPartition
+        B1 = BroadCast(A1, (m, 2); threaded)
+        xpart = ArrayPartition(randn(m), randn(m))
+        y_base = B1 * xpart
+        p = [2,1]
+        B1p = AbstractOperators.permute(B1, p)
+        xpart_p = ArrayPartition(xpart.x[p]...)
+        y_perm = B1p * xpart_p
+        @test y_perm == y_base  # same broadcasted sum after permutation inversion
 
-    # Adjoint path exercise for OperatorBroadCast (non-threaded) to hit get_input_slice
-    r = randn(size(B1,1))
-    g = B1' * r
-    @test length(g) == length(xpart.x[1]) + length(xpart.x[2])
+        # Adjoint path exercise for OperatorBroadCast (non-threaded) to hit get_input_slice
+        r = randn(size(B1,1))
+        g = B1' * r
+        @test length(g) == length(xpart.x[1]) + length(xpart.x[2])
+    end
 
     # If multi-threading available, test threaded variant basics (skip if only 1 thread)
     if Threads.nthreads() > 1
@@ -221,11 +224,18 @@ Random.seed!(0)
     @test all(y .== 0)
 
     # Edge: BroadCast of Eye
-    opE = Eye(2)
-    opRe = BroadCast(opE, (2, 3))
-    xe = randn(2)
+    opE = Eye(200)
+    opRe = BroadCast(opE, (200, 350); threaded=false)
+    xe = randn(200)
     y = opRe * xe
     @test all(y[:,1] .== xe)
+    opRe = BroadCast(opE, (200, 350); threaded=true)
+    xe = randn(200)
+    y = opRe * xe
+    @test all(y[:,1] .== xe)
+    @test is_linear(opRe) == true
+    @test is_null(opRe) == false
+    @test AbstractOperators.has_fast_opnorm(opRe) == true
 
     # Edge: BroadCast of DiagOp
     d = randn(2)
@@ -283,6 +293,7 @@ Random.seed!(0)
         @test B1 != B3
         
         # opnorm for OperatorBroadCast
+        @test AbstractOperators.has_fast_opnorm(B1) == AbstractOperators.has_fast_opnorm(E1)
         A_op = MatrixOp(randn(3, 2))
         B_op = BroadCast(A_op, (3, 4); threaded=false)
         @test opnorm(B_op) ≈ opnorm(A_op)
@@ -291,6 +302,10 @@ Random.seed!(0)
             B_op_t = BroadCast(A_op, (3, 4); threaded=true)
             @test opnorm(B_op_t) ≈ opnorm(A_op)
         end
+
+        # wrong output size
+        A = DiagOp(rand(4, 3, 2))
+        @test_throws ErrorException BroadCast(A, (4, 2))
     end
 
     @testset "Threaded NoOperatorBroadCast" begin

--- a/test/calculus/test_compose.jl
+++ b/test/calculus/test_compose.jl
@@ -195,7 +195,7 @@ end
     D2 = FiniteDiff((3,))
     CC = Compose(D1, D2)
     opnorm_CC = opnorm(CC)
-    @test abs(opnorm_CC - estimate_opnorm(CC)) / opnorm_CC < 0.25
+    @test opnorm_CC ≈ estimate_opnorm(CC) rtol=0.05
 
     # permute utility
     A1 = MatrixOp(randn(2,2))

--- a/test/calculus/test_compose.jl
+++ b/test/calculus/test_compose.jl
@@ -4,6 +4,7 @@ end
 if !isdefined(Main, :test_op)
     include("../utils.jl")
 end
+Random.seed!(0)
 
 @testset "Compose" begin
     verb && println(" --- Testing Compose --- ")

--- a/test/calculus/test_dcat.jl
+++ b/test/calculus/test_dcat.jl
@@ -4,6 +4,7 @@ end
 if !isdefined(Main, :test_op)
     include("../utils.jl")
 end
+Random.seed!(0)
 import Base: size
 
 @testset "DCAT" begin

--- a/test/calculus/test_dcat.jl
+++ b/test/calculus/test_dcat.jl
@@ -153,6 +153,7 @@ import Base: size
     # Test opnorm and estimate_opnorm
     opA3 = MatrixOp([1.0 0.0; 0.0 3.0])
     opD4 = DCAT(opA1, opA3)
+    @test AbstractOperators.has_fast_opnorm(opD4) == (AbstractOperators.has_fast_opnorm(opA1) && AbstractOperators.has_fast_opnorm(opA3))
     @test opnorm(opD4) ≈ estimate_opnorm(opD4) rtol=0.05
 
     # Test == for general equality

--- a/test/calculus/test_dcat.jl
+++ b/test/calculus/test_dcat.jl
@@ -152,7 +152,7 @@ import Base: size
     # Test opnorm and estimate_opnorm
     opA3 = MatrixOp([1.0 0.0; 0.0 3.0])
     opD4 = DCAT(opA1, opA3)
-    @test opnorm(opD4) ≈ estimate_opnorm(opD4)
+    @test opnorm(opD4) ≈ estimate_opnorm(opD4) rtol=0.05
 
     # Test == for general equality
     opD5a = DCAT(opA1, opA2)

--- a/test/calculus/test_hcat.jl
+++ b/test/calculus/test_hcat.jl
@@ -4,6 +4,7 @@ end
 if !isdefined(Main, :test_op)
     include("../utils.jl")
 end
+Random.seed!(0)
 
 @testset "HCAT" begin
     verb && println(" --- Testing HCAT --- ")

--- a/test/calculus/test_reshape.jl
+++ b/test/calculus/test_reshape.jl
@@ -181,7 +181,7 @@ end
     @test y_orig ≈ y_perm
 
     # opnorm passthrough
-    @test opnorm(R1) == opnorm(Aeq)
+    @test opnorm(R1) ≈ opnorm(Aeq)
 
     # remove_displacement idempotence with displacement underlying
     dA = randn(m)

--- a/test/calculus/test_reshape.jl
+++ b/test/calculus/test_reshape.jl
@@ -4,6 +4,7 @@ end
 if !isdefined(Main, :test_op)
     include("../utils.jl")
 end
+Random.seed!(0)
 
 @testset "Reshape" begin
     verb && println(" --- Testing Reshape --- ")

--- a/test/calculus/test_reshape.jl
+++ b/test/calculus/test_reshape.jl
@@ -182,6 +182,7 @@ Random.seed!(0)
     @test y_orig ≈ y_perm
 
     # opnorm passthrough
+    @test AbstractOperators.has_fast_opnorm(R1) == AbstractOperators.has_fast_opnorm(Aeq)
     @test opnorm(R1) ≈ opnorm(Aeq)
 
     # remove_displacement idempotence with displacement underlying

--- a/test/calculus/test_scale.jl
+++ b/test/calculus/test_scale.jl
@@ -146,7 +146,7 @@ end
     # opnorm and estimate_opnorm passthrough
     opnorm_S = opnorm(S1)
     @test opnorm_S ≈ abs(S1.coeff) * opnorm(Aeq)
-    @test abs(opnorm_S - estimate_opnorm(S1)) / opnorm_S < 0.02
+    @test opnorm_S ≈ estimate_opnorm(S1) rtol=0.05
 
     # remove_displacement idempotence with displacement underlying
     dA = randn(m)
@@ -293,7 +293,7 @@ end
         α = -1.2
         S = Scale(α, A)
         @test opnorm(S) ≈ abs(α) * opnorm(A)
-        @test isapprox(AbstractOperators.estimate_opnorm(S), abs(α)*AbstractOperators.estimate_opnorm(A); rtol=1e-3)
+        @test estimate_opnorm(S) ≈ opnorm(S) rtol=0.05
     end
 
     @testset "Scale permute utility" begin

--- a/test/calculus/test_scale.jl
+++ b/test/calculus/test_scale.jl
@@ -145,7 +145,7 @@ end
 
     # opnorm and estimate_opnorm passthrough
     opnorm_S = opnorm(S1)
-    @test opnorm_S ≈ abs(S1.coeff) * opnorm(Aeq)
+    @test opnorm_S ≈ abs(S1.coeff) * opnorm(Aeq) rtol=5e-6
     @test opnorm_S ≈ estimate_opnorm(S1) rtol=0.05
 
     # remove_displacement idempotence with displacement underlying

--- a/test/calculus/test_scale.jl
+++ b/test/calculus/test_scale.jl
@@ -9,6 +9,7 @@ end
 if !isdefined(Main, :test_op)
     include("../utils.jl")
 end
+Random.seed!(0)
 
 @testset "Scale" begin
     verb && println(" --- Testing Scale --- ")

--- a/test/calculus/test_scale.jl
+++ b/test/calculus/test_scale.jl
@@ -237,6 +237,8 @@ Random.seed!(0)
         @test AbstractOperators.diag(S) == α * AbstractOperators.diag(A)
         @test AbstractOperators.diag_AcA(S) == α^2 * AbstractOperators.diag_AcA(A)
         @test AbstractOperators.diag_AAc(S) == α^2 * AbstractOperators.diag_AAc(A)
+        @test is_full_row_rank(S) == is_full_row_rank(A)
+        @test is_full_column_rank(S) == is_full_column_rank(A)
     end
 
     @testset "Scale real vs complex coefficient error path" begin
@@ -293,6 +295,7 @@ Random.seed!(0)
         A = MatrixOp(randn(7,4))
         α = -1.2
         S = Scale(α, A)
+        @test AbstractOperators.has_fast_opnorm(S) == AbstractOperators.has_fast_opnorm(A)
         @test opnorm(S) ≈ abs(α) * opnorm(A)
         @test estimate_opnorm(S) ≈ opnorm(S) rtol=0.05
     end

--- a/test/calculus/test_sum.jl
+++ b/test/calculus/test_sum.jl
@@ -137,7 +137,7 @@ end
     # estimate_opnorm aggregator
     opnorm_S1 = opnorm(S1)
     estimated_opnorm_S1 = estimate_opnorm(S1)
-    @test abs(estimated_opnorm_S1 - opnorm_S1) / opnorm_S1 < 0.03
+    @test estimated_opnorm_S1 ≈ opnorm_S1 rtol=0.05
 
     # remove_displacement idempotence with displacement underlying
     dA = randn(m)

--- a/test/calculus/test_sum.jl
+++ b/test/calculus/test_sum.jl
@@ -4,6 +4,7 @@ end
 if !isdefined(Main, :test_op)
     include("../utils.jl")
 end
+Random.seed!(0)
 
 @testset "Sum" begin
     verb && println(" --- Testing Sum --- ")

--- a/test/calculus/test_vcat.jl
+++ b/test/calculus/test_vcat.jl
@@ -4,6 +4,7 @@ end
 if !isdefined(Main, :test_op)
     include("../utils.jl")
 end
+Random.seed!(0)
 
 @testset "VCAT" begin
     verb && println(" --- Testing VCAT --- ")

--- a/test/linearoperators/test_diagop.jl
+++ b/test/linearoperators/test_diagop.jl
@@ -97,7 +97,7 @@ end
 
     # storage and type related helpers
     @test is_thread_safe(op) == true
-    @test LinearAlgebra.opnorm(op) == maximum(abs, diag(op))
+    @test opnorm(op) == maximum(abs, diag(op))
     @test estimate_opnorm(op) == maximum(abs, diag(op))
     @test AbstractOperators.has_optimized_normalop(op) == true
     @test AbstractOperators.has_optimized_normalop(op') == true

--- a/test/linearoperators/test_diagop.jl
+++ b/test/linearoperators/test_diagop.jl
@@ -98,6 +98,7 @@ Random.seed!(0)
 
     # storage and type related helpers
     @test is_thread_safe(op) == true
+    @test AbstractOperators.has_fast_opnorm(op) == true
     @test opnorm(op) == maximum(abs, diag(op))
     @test estimate_opnorm(op) == maximum(abs, diag(op))
     @test AbstractOperators.has_optimized_normalop(op) == true

--- a/test/linearoperators/test_diagop.jl
+++ b/test/linearoperators/test_diagop.jl
@@ -4,6 +4,7 @@ end
 if !isdefined(Main, :test_op)
     include("../utils.jl")
 end
+Random.seed!(0)
 
 @testset "DiagOp" begin
     verb && println(" --- Testing DiagOp --- ")

--- a/test/linearoperators/test_eye.jl
+++ b/test/linearoperators/test_eye.jl
@@ -61,8 +61,8 @@ end
 
     # Adjoint, opnorm, get_normal_op
     @test AdjointOperator(op) === op
-    @test LinearAlgebra.opnorm(op) == 1.0
-    @test LinearAlgebra.opnorm(op) == estimate_opnorm(op)
+    @test opnorm(op) == 1.0
+    @test opnorm(op) == estimate_opnorm(op)
     @test AbstractOperators.has_optimized_normalop(op) == true
     @test AbstractOperators.get_normal_op(op) === op
 

--- a/test/linearoperators/test_eye.jl
+++ b/test/linearoperators/test_eye.jl
@@ -4,6 +4,7 @@ end
 if !isdefined(Main, :test_op)
     include("../utils.jl")
 end
+Random.seed!(0)
 
 @testset "Eye" begin
     verb && println(" --- Testing Eye --- ")

--- a/test/linearoperators/test_eye.jl
+++ b/test/linearoperators/test_eye.jl
@@ -62,6 +62,7 @@ Random.seed!(0)
 
     # Adjoint, opnorm, get_normal_op
     @test AdjointOperator(op) === op
+    @test AbstractOperators.has_fast_opnorm(op) == true
     @test opnorm(op) == 1.0
     @test opnorm(op) == estimate_opnorm(op)
     @test AbstractOperators.has_optimized_normalop(op) == true

--- a/test/linearoperators/test_finitediff.jl
+++ b/test/linearoperators/test_finitediff.jl
@@ -4,6 +4,7 @@ end
 if !isdefined(Main, :test_op)
     include("../utils.jl")
 end
+Random.seed!(0)
 using SparseArrays
 
 @testset "FiniteDiff" begin

--- a/test/linearoperators/test_getindex.jl
+++ b/test/linearoperators/test_getindex.jl
@@ -4,6 +4,7 @@ end
 if !isdefined(Main, :test_op)
     include("../utils.jl")
 end
+Random.seed!(0)
 using LinearAlgebra
 
 @testset "GetIndex" begin

--- a/test/linearoperators/test_getindex.jl
+++ b/test/linearoperators/test_getindex.jl
@@ -119,7 +119,8 @@ using LinearAlgebra
     @test typeof(base_eye) <: Eye
     @test size(base_eye) == (size(A, 1), size(A, 1))
 
-    # opnorm vs estimate_opnorm (no direct has_fast_opnorm check)
+    # opnorm vs estimate_opnorm
+    @test AbstractOperators.has_fast_opnorm(A) == true
     @test opnorm(A) == estimate_opnorm(A)
 
     # show output should contain arrow-like symbol for GetIndex

--- a/test/linearoperators/test_getindex.jl
+++ b/test/linearoperators/test_getindex.jl
@@ -119,7 +119,7 @@ using LinearAlgebra
     @test size(base_eye) == (size(A, 1), size(A, 1))
 
     # opnorm vs estimate_opnorm (no direct has_fast_opnorm check)
-    @test LinearAlgebra.opnorm(A) == estimate_opnorm(A)
+    @test opnorm(A) == estimate_opnorm(A)
 
     # show output should contain arrow-like symbol for GetIndex
     io = IOBuffer(); show(io, A); strA = String(take!(io)); @test occursin("↓", strA)

--- a/test/linearoperators/test_lmatrixop.jl
+++ b/test/linearoperators/test_lmatrixop.jl
@@ -4,6 +4,7 @@ end
 if !isdefined(Main, :test_op)
     include("../utils.jl")
 end
+Random.seed!(0)
 
 @testset "LMatrixOp" begin
     verb && println(" --- Testing LMatrixOp --- ")

--- a/test/linearoperators/test_matrixop.jl
+++ b/test/linearoperators/test_matrixop.jl
@@ -128,7 +128,7 @@ end
 
     # opnorm vs estimate_opnorm
     @test opnorm(invop) ≈ estimate_opnorm(invop)
-    @test opnorm(invop) == opnorm(B)
+    @test opnorm(invop) ≈ opnorm(B)
 
     # Size variations: single vs multi-column
     Tall = randn(8,3)

--- a/test/linearoperators/test_matrixop.jl
+++ b/test/linearoperators/test_matrixop.jl
@@ -6,6 +6,7 @@ end
 if !isdefined(Main, :test_op)
     include("../utils.jl")
 end
+Random.seed!(0)
 
 @testset "MatrixOp" begin
     verb && println(" --- Testing MatrixOp --- ")

--- a/test/linearoperators/test_matrixop.jl
+++ b/test/linearoperators/test_matrixop.jl
@@ -127,8 +127,8 @@ end
     @test Ymat ≈ Qmat * Xmat
 
     # opnorm vs estimate_opnorm
-    @test LinearAlgebra.opnorm(invop) ≈ estimate_opnorm(invop)
-    @test LinearAlgebra.opnorm(invop) == LinearAlgebra.opnorm(B)
+    @test opnorm(invop) ≈ estimate_opnorm(invop)
+    @test opnorm(invop) == opnorm(B)
 
     # Size variations: single vs multi-column
     Tall = randn(8,3)

--- a/test/linearoperators/test_mylinop.jl
+++ b/test/linearoperators/test_mylinop.jl
@@ -4,6 +4,7 @@ end
 if !isdefined(Main, :test_op)
     include("../utils.jl")
 end
+Random.seed!(0)
 
 @testset "MyLinOp" begin
     verb && println(" --- Testing MyLinOp --- ")

--- a/test/linearoperators/test_variation.jl
+++ b/test/linearoperators/test_variation.jl
@@ -4,6 +4,7 @@ end
 if !isdefined(Main, :test_op)
     include("../utils.jl")
 end
+Random.seed!(0)
 
 using SparseArrays
 

--- a/test/linearoperators/test_zeropad.jl
+++ b/test/linearoperators/test_zeropad.jl
@@ -18,7 +18,7 @@ end
     @test domain_type(op) == Float64
     @test codomain_type(op) == Float64
     @test is_thread_safe(op) == true
-    @test LinearAlgebra.opnorm(op) == 1
+    @test opnorm(op) == 1
 
     n = (3, 2)
     z = (5, 3)

--- a/test/linearoperators/test_zeropad.jl
+++ b/test/linearoperators/test_zeropad.jl
@@ -4,6 +4,7 @@ end
 if !isdefined(Main, :test_op)
     include("../utils.jl")
 end
+Random.seed!(0)
 
 @testset "ZeroPad" begin
     verb && println(" --- Testing ZeroPad --- ")

--- a/test/linearoperators/test_zeropad.jl
+++ b/test/linearoperators/test_zeropad.jl
@@ -19,6 +19,7 @@ Random.seed!(0)
     @test domain_type(op) == Float64
     @test codomain_type(op) == Float64
     @test is_thread_safe(op) == true
+    @test AbstractOperators.has_fast_opnorm(op) == true
     @test opnorm(op) == 1
 
     n = (3, 2)

--- a/test/linearoperators/test_zerosop.jl
+++ b/test/linearoperators/test_zerosop.jl
@@ -21,6 +21,7 @@ Random.seed!(0)
     @test domain_type(op) == D
     @test codomain_type(op) == C
     @test is_thread_safe(op) == true
+    @test AbstractOperators.has_fast_opnorm(op) == true
     @test opnorm(op) == 0
 
     # Adjoint returns zeros of domain shape

--- a/test/linearoperators/test_zerosop.jl
+++ b/test/linearoperators/test_zerosop.jl
@@ -4,6 +4,7 @@ end
 if !isdefined(Main, :test_op)
     include("../utils.jl")
 end
+Random.seed!(0)
 
 @testset "Zeros" begin
     verb && println(" --- Testing Zeros --- ")

--- a/test/linearoperators/test_zerosop.jl
+++ b/test/linearoperators/test_zerosop.jl
@@ -20,7 +20,7 @@ end
     @test domain_type(op) == D
     @test codomain_type(op) == C
     @test is_thread_safe(op) == true
-    @test LinearAlgebra.opnorm(op) == 0
+    @test opnorm(op) == 0
 
     # Adjoint returns zeros of domain shape
     z = zeros(n)


### PR DESCRIPTION
Running tests with 2 threads (required for testing multithreading functionalities) made the test nondeterministic, which, in turn, caused the tests of `opnorm` and `estimate_opnorm` to fail sometimes because they might start from a random state.

In this PR, I investigated this issue, fine-tuned the parameters of these functions (the previous PR was basically just a quick fix), and fixed the test to check for the same relative tolerance for `opnorm` values (square root of eps -- the default value for approx function) and `estimate_opnorm` values (0.05). I ran the tests many times, and now I hope that this is finally a robust fix for the problem.