### PR TITLE
Break apart ci.yml to documentation.yml and tests.yml, and fix documentation trigger condition

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,0 +1,25 @@
+name: Documenter
+on:
+  push:
+    branches: master
+    tags: [v*]
+  pull_request:
+
+jobs:
+  Documenter:
+    permissions:
+      contents: write
+      statuses: write
+    name: Documentation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: '1'
+          show-versioninfo: true               # this causes versioninfo to be printed to the action log
+      - uses: julia-actions/cache@v2           # cache using https://github.com/julia-actions/cache
+      - uses: julia-actions/julia-buildpkg@v1  # if package requires Pkg.build()
+      - uses: julia-actions/julia-docdeploy@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Tests
 
 on:
   push:
@@ -42,22 +42,3 @@ jobs:
           files: lcov.info
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-  Documentation:
-    name: Documentation
-    runs-on: ubuntu-latest
-
-    permissions:
-      contents: write
-      statuses: write
-
-    steps:
-      - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v2
-        with:
-          version: '1'
-          show-versioninfo: true               # this causes versioninfo to be printed to the action log
-      - uses: julia-actions/cache@v2
-      - uses: julia-actions/julia-buildpkg@v1  # if package requires Pkg.build()
-      - uses: julia-actions/julia-docdeploy@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Documentation for the latest release (v0.4.0) still appears as `dev`. This PR tries to fix this.