### PR TITLE
bump NFFTOperators version

### DIFF
--- a/NFFTOperators/Project.toml
+++ b/NFFTOperators/Project.toml
@@ -1,6 +1,6 @@
 name = "NFFTOperators"
 uuid = "35a93202-2abf-4a13-bc94-0aee2f861ee0"
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 AbstractOperators = "d9c5613a-d543-52d8-9afd-8f241a8c3f1c"


### PR DESCRIPTION
This PR bumps the NFFTOperators version from v0.1.0 to v0.1.1.