### PR TITLE
Custom benchmarking script

### DIFF
--- a/.github/skills/julia-long-test-workflow/SKILL.md
+++ b/.github/skills/julia-long-test-workflow/SKILL.md
@@ -37,7 +37,10 @@ TestItemRunner.run_tests(pwd(); filter = ti -> :MatrixOp in ti.tags) # example o
 TestItemRunner.run_tests(pwd(); filter = ti -> ti.name == "DCT") # example of filtering by test name instead of tags
 ```
 
-AirSpeedVelocity comparison:
+### Local benchmark comparison with AirspeedVelocity
+
+AirspeedVelocity works well for local branch-vs-master comparisons and is the
+recommended tool for interactive performance investigation:
 
 ```sh
 benchpkg \
@@ -57,6 +60,44 @@ benchpkgtable \
   --input-dir .temp/asv \
   --ratio \
   --mode time,memory
+```
+
+> **Note:** Use AirspeedVelocity with an explicit `--script` path when comparing
+> against revisions that do not yet contain the benchmark file.
+
+### CI benchmark comparison (GitHub Actions)
+
+The GitHub Actions benchmark CI does **not** use the AirspeedVelocity action
+because the root-level Julia workspace (`[workspace]` in `Project.toml`) causes
+that action's revision-management to mis-resolve the monorepo subprojects.
+Instead, two workflows implement a fork-safe two-stage approach:
+
+- **`benchmark.yml`** – unprivileged `pull_request` job that checks out both
+  the base and head revisions, runs `benchmark/compare.jl` against explicit
+  worktree paths, and uploads `body.md`, `pr_number.txt`, and
+  `julia_version.txt` as an artifact.
+- **`post_benchmark_comment.yml`** – privileged `workflow_run` job that
+  downloads the artifact and creates or updates the PR comment.
+
+The comparison table mirrors AirspeedVelocity output with separate Time and
+Memory sections, base/head columns, a ratio column, and emoji indicators:
+- 🚀 significant speedup: `ratio − ratio_err > 1.2` (time) or `ratio < 0.5` (memory)
+- 🐢 significant slowdown: `ratio + ratio_err < 0.8` (time) or `ratio > 1.5` (memory)
+
+To run the comparison locally with the same script used by CI:
+
+```sh
+# Check out base separately, e.g. in a worktree:
+git worktree add .temp/base master
+
+julia --project=benchmark benchmark/compare.jl \
+  --base-dir  .temp/base \
+  --head-dir  . \
+  --output-dir .temp/bench-compare \
+  --pr        0 \
+  --julia-version "$(julia -e 'print(VERSION)')"
+
+cat .temp/bench-compare/body.md
 ```
 
 ## Done Criteria

--- a/.github/skills/julia-long-test-workflow/SKILL.md
+++ b/.github/skills/julia-long-test-workflow/SKILL.md
@@ -37,10 +37,7 @@ TestItemRunner.run_tests(pwd(); filter = ti -> :MatrixOp in ti.tags) # example o
 TestItemRunner.run_tests(pwd(); filter = ti -> ti.name == "DCT") # example of filtering by test name instead of tags
 ```
 
-### Local benchmark comparison with AirspeedVelocity
-
-AirspeedVelocity works well for local branch-vs-master comparisons and is the
-recommended tool for interactive performance investigation:
+AirSpeedVelocity comparison:
 
 ```sh
 benchpkg \
@@ -60,44 +57,6 @@ benchpkgtable \
   --input-dir .temp/asv \
   --ratio \
   --mode time,memory
-```
-
-> **Note:** Use AirspeedVelocity with an explicit `--script` path when comparing
-> against revisions that do not yet contain the benchmark file.
-
-### CI benchmark comparison (GitHub Actions)
-
-The GitHub Actions benchmark CI does **not** use the AirspeedVelocity action
-because the root-level Julia workspace (`[workspace]` in `Project.toml`) causes
-that action's revision-management to mis-resolve the monorepo subprojects.
-Instead, two workflows implement a fork-safe two-stage approach:
-
-- **`benchmark.yml`** – unprivileged `pull_request` job that checks out both
-  the base and head revisions, runs `benchmark/compare.jl` against explicit
-  worktree paths, and uploads `body.md`, `pr_number.txt`, and
-  `julia_version.txt` as an artifact.
-- **`post_benchmark_comment.yml`** – privileged `workflow_run` job that
-  downloads the artifact and creates or updates the PR comment.
-
-The comparison table mirrors AirspeedVelocity output with separate Time and
-Memory sections, base/head columns, a ratio column, and emoji indicators:
-- 🚀 significant speedup: `ratio − ratio_err > 1.2` (time) or `ratio < 0.5` (memory)
-- 🐢 significant slowdown: `ratio + ratio_err < 0.8` (time) or `ratio > 1.5` (memory)
-
-To run the comparison locally with the same script used by CI:
-
-```sh
-# Check out base separately, e.g. in a worktree:
-git worktree add .temp/base master
-
-julia --project=benchmark benchmark/compare.jl \
-  --base-dir  .temp/base \
-  --head-dir  . \
-  --output-dir .temp/bench-compare \
-  --pr        0 \
-  --julia-version "$(julia -e 'print(VERSION)')"
-
-cat .temp/bench-compare/body.md
 ```
 
 ## Done Criteria

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,14 +1,79 @@
 name: Benchmark this PR
+# Stage 1 (fork-safe): runs with read-only permissions, uploads results as an
+# artifact.  Stage 2 (post_benchmark_comment.yml) picks up the artifact and
+# posts the PR comment with write permissions.
 on:
-  pull_request_target:
-    branches: [ master ]  # change to your default branch
-permissions:
-  pull-requests: write    # needed to post comments
+  pull_request:
+    branches: [ master ]
+
+# No write permissions needed here – the comment is posted by the separate
+# post_benchmark_comment.yml workflow_run job.
 
 jobs:
   bench:
     runs-on: ubuntu-latest
     steps:
-      - uses: MilesCranmer/AirspeedVelocity.jl@action-v1
+      # ------------------------------------------------------------------
+      # Check out HEAD commit of the PR (the code under review)
+      # ------------------------------------------------------------------
+      - name: Check out PR head
+        uses: actions/checkout@v4
         with:
-          julia-version: '1'
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: head
+          fetch-depth: 0     # needed so we can also check out base SHA
+
+      # ------------------------------------------------------------------
+      # Check out the merge-base / target branch (master) as "base"
+      # ------------------------------------------------------------------
+      - name: Check out base (master)
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: base
+
+      # ------------------------------------------------------------------
+      # Julia + package cache
+      # ------------------------------------------------------------------
+      - name: Set up Julia
+        uses: julia-actions/setup-julia@v2
+        with:
+          version: '1'
+
+      - name: Cache Julia packages
+        uses: julia-actions/cache@v2
+
+      # ------------------------------------------------------------------
+      # Instantiate the benchmark sub-project (installs all deps declared
+      # in benchmark/Project.toml, including ArgParse and BenchmarkTools).
+      # ------------------------------------------------------------------
+      - name: Instantiate benchmark project
+        shell: bash
+        run: julia --project=head/benchmark -e 'using Pkg; Pkg.instantiate()'
+
+      # ------------------------------------------------------------------
+      # Run the repo-local comparison driver
+      # ------------------------------------------------------------------
+      - name: Run benchmark comparison
+        shell: bash
+        env:
+          JULIA_NUM_THREADS: 2
+        run: |
+          julia --project=head/benchmark head/benchmark/compare.jl \
+            --base-dir  "${{ github.workspace }}/base" \
+            --head-dir  "${{ github.workspace }}/head" \
+            --output-dir artifact \
+            --pr        "${{ github.event.pull_request.number }}" \
+            --julia-version "$(julia -e 'print(VERSION)')"
+
+      # ------------------------------------------------------------------
+      # Upload artifact for stage-2 comment posting
+      # ------------------------------------------------------------------
+      - name: Upload benchmark comment artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-comment-1
+          path: |
+            artifact/body.md
+            artifact/pr_number.txt
+            artifact/julia_version.txt

--- a/.github/workflows/post_benchmark_comment.yml
+++ b/.github/workflows/post_benchmark_comment.yml
@@ -1,0 +1,66 @@
+name: Post Benchmark Comment
+# Stage 2 (privileged): triggered when the unprivileged benchmark.yml
+# workflow completes.  Downloads the benchmark artifact produced by that run
+# and creates or updates a PR comment.
+#
+# IMPORTANT: this file must exist on the default branch (master) before
+# workflow_run can trigger it.  Merge this file to master before opening
+# the first PR that should receive a benchmark comment.
+on:
+  workflow_run:
+    workflows: ["Benchmark this PR"]
+    types: [completed]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  comment:
+    # Only run when the benchmark workflow itself succeeded.
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download benchmark artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: benchmark-comment-*
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+          path: artifacts
+
+      - name: Post or update PR comment
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          shopt -s nullglob
+
+          for dir in artifacts/*/; do
+            [[ -f "$dir/pr_number.txt"    ]] || continue
+            [[ -f "$dir/julia_version.txt" ]] || continue
+            [[ -f "$dir/body.md"           ]] || continue
+
+            pr=$(cat "$dir/pr_number.txt")
+            jv=$(cat "$dir/julia_version.txt")
+
+            # Look for an existing comment from this bot that contains the
+            # Julia-version marker so we can update it instead of duplicating.
+            comment_id=$(gh api \
+              "repos/${{ github.repository }}/issues/${pr}/comments" \
+              --paginate \
+              --jq ".[] | select(
+                .user.login == \"github-actions[bot]\" and
+                (.body | contains(\"Benchmark Results (Julia v${jv})\"))
+              ) | .id" \
+              | head -1)
+
+            if [[ -n "$comment_id" ]]; then
+              gh api --method PATCH \
+                "repos/${{ github.repository }}/issues/comments/${comment_id}" \
+                -F body=@"$dir/body.md"
+            else
+              gh api --method POST \
+                "repos/${{ github.repository }}/issues/${pr}/comments" \
+                -F body=@"$dir/body.md"
+            fi
+          done

--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 AbstractOperators = "d9c5613a-d543-52d8-9afd-8f241a8c3f1c"
+ArgParse = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 DSPOperators = "d5a72628-6e2f-430e-82f5-561df0bb8116"
 FFTWOperators = "c59a084b-ba08-4f3f-af9e-f4298d6caa94"
@@ -7,4 +8,6 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 NFFTOperators = "35a93202-2abf-4a13-bc94-0aee2f861ee0"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
+Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 WaveletOperators = "f3582904-6f60-4bbd-985d-55eab799bc9d"

--- a/benchmark/compare.jl
+++ b/benchmark/compare.jl
@@ -1,0 +1,350 @@
+#!/usr/bin/env julia
+# benchmark/compare.jl
+#
+# Repo-local benchmark comparison driver for CI.
+# Runs benchmark/benchmarks.jl at two explicit source trees, serialises results
+# with BenchmarkTools, then renders a markdown PR-comment body to body.md.
+#
+# Usage (called from .github/workflows/benchmark.yml):
+#   julia --project=benchmark benchmark/compare.jl \
+#       --base-dir  <path-to-base-checkout>  \
+#       --head-dir  <path-to-head-checkout>  \
+#       --output-dir <artifact-dir>           \
+#       --pr        <PR-number>               \
+#       --julia-version <julia-version-string>
+#
+# The script writes three files to --output-dir:
+#   body.md          – markdown comment body ready for posting
+#   pr_number.txt    – PR number (for the post-comment workflow)
+#   julia_version.txt – Julia version string (for the post-comment workflow)
+
+using ArgParse
+using BenchmarkTools
+using Pkg
+using Printf
+using Serialization
+using Statistics
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+function parse_args_local(args)
+    s = ArgParseSettings()
+    @add_arg_table! s begin
+        "--base-dir"
+            help    = "Absolute path to base revision checkout"
+            arg_type = String
+            required = true
+        "--head-dir"
+            help    = "Absolute path to head revision checkout"
+            arg_type = String
+            required = true
+        "--output-dir"
+            help    = "Directory where body.md and metadata are written"
+            arg_type = String
+            default  = "."
+        "--pr"
+            help    = "Pull-request number"
+            arg_type = String
+            default  = ""
+        "--julia-version"
+            help    = "Julia version string for the comment header"
+            arg_type = String
+            default  = string(VERSION)
+    end
+    return parse_args(args, s)
+end
+
+# ---------------------------------------------------------------------------
+# Benchmark execution
+# ---------------------------------------------------------------------------
+
+"""
+Run benchmark/benchmarks.jl inside `repo_dir` in a clean subprocess and return
+the serialised BenchmarkGroup results path.  The subprocess activates the
+benchmark sub-project so all workspace/subproject resolution happens via the
+standard local manifest.
+"""
+function run_suite(repo_dir::AbstractString, result_path::AbstractString)
+    bench_project = joinpath(repo_dir, "benchmark")
+    bench_script  = joinpath(repo_dir, "benchmark", "benchmarks.jl")
+
+    # The runner script activates the benchmark project, includes benchmarks.jl,
+    # tunes and runs SUITE, then serialises results.
+    runner = """
+    using Pkg
+    Pkg.activate($(repr(bench_project)); io = devnull)
+    Pkg.instantiate(; io = devnull)
+    include($(repr(bench_script)))
+    BenchmarkTools.tune!(SUITE)
+    results = BenchmarkTools.run(SUITE; verbose = false)
+    using Serialization
+    Serialization.serialize($(repr(result_path)), results)
+    """
+
+    cmd = `$(Base.julia_cmd()) --startup-file=no --project=$(bench_project) -e $(runner)`
+    @info "Running benchmarks at $repo_dir …"
+    run(cmd)
+    return result_path
+end
+
+# ---------------------------------------------------------------------------
+# Comparison helpers  (logic mirrors AirspeedVelocity TableUtils / PR #140)
+# ---------------------------------------------------------------------------
+
+"""
+Flatten a possibly nested BenchmarkGroup into a Dict{String,BenchmarkTools.Trial}
+using "/" as the key separator.
+"""
+function flatten_group(group::BenchmarkGroup, prefix = "")
+    out = Dict{String,BenchmarkTools.Trial}()
+    for (k, v) in group
+        key = isempty(prefix) ? string(k) : "$prefix/$k"
+        if v isa BenchmarkGroup
+            merge!(out, flatten_group(v, key))
+        elseif v isa BenchmarkTools.Trial
+            out[key] = v
+        end
+    end
+    return out
+end
+
+# ---- time formatting -------------------------------------------------------
+
+const TIME_UNITS = [(:ns, 1e0), (Symbol("μs"), 1e3), (:ms, 1e6), (:s, 1e9)]
+
+function auto_time_unit(t_ns::Float64)
+    for (unit, scale) in reverse(TIME_UNITS)
+        t_ns / scale >= 1.0 && return (unit, scale)
+    end
+    return TIME_UNITS[1]
+end
+
+function format_time(t::BenchmarkTools.Trial)
+    med = Statistics.median(t.times)   # nanoseconds
+    lo  = Statistics.quantile(t.times, 0.25)
+    hi  = Statistics.quantile(t.times, 0.75)
+    unit, scale = auto_time_unit(med)
+    v    = med / scale
+    verr = max(0.0, (hi - lo) / 2) / scale
+    unit_str = string(unit)
+    if isfinite(verr) && verr > 0
+        return @sprintf("%.3g ± %.2g %s", v, verr, unit_str)
+    else
+        return @sprintf("%.3g %s", v, unit_str)
+    end
+end
+
+# ---- memory formatting -----------------------------------------------------
+
+function format_memory(t::BenchmarkTools.Trial)
+    allocs = round(Int, Statistics.median(t.allocs))
+    bytes  = round(Int, Statistics.median(t.memory))
+    if bytes == 0
+        return "0 allocs (0 bytes)"
+    elseif bytes < 1024
+        return "$allocs allocs ($bytes bytes)"
+    elseif bytes < 1024^2
+        return @sprintf("%d allocs (%.2f KiB)", allocs, bytes / 1024)
+    else
+        return @sprintf("%d allocs (%.2f MiB)", allocs, bytes / 1024^2)
+    end
+end
+
+# ---- ratio + emoji ---------------------------------------------------------
+
+"""
+Compute ratio base/head for the given mode (:time or :memory).
+Returns `(ratio, ratio_err)` where `ratio_err` is finite only for time mode.
+Semantics: ratio > 1 means head is faster (speedup), ratio < 1 means slowdown.
+"""
+function compute_ratio(base::BenchmarkTools.Trial, head::BenchmarkTools.Trial, mode::Symbol)
+    if mode === :time
+        base_med = Statistics.median(base.times)
+        head_med = Statistics.median(head.times)
+        ratio = base_med / head_med
+        # interquartile-range based error propagation
+        base_err = max(0.0, Statistics.quantile(base.times, 0.75) - Statistics.quantile(base.times, 0.25))
+        head_err = max(0.0, Statistics.quantile(head.times, 0.75) - Statistics.quantile(head.times, 0.25))
+        ratio_err = abs(ratio) * sqrt((base_err / base_med)^2 + (head_err / head_med)^2)
+        return ratio, ratio_err
+    else  # :memory
+        base_mem = Statistics.median(base.memory)
+        head_mem = Statistics.median(head.memory)
+        if head_mem == 0
+            return (base_mem == 0 ? 1.0 : Inf), NaN
+        end
+        return base_mem / head_mem, NaN
+    end
+end
+
+"""
+Emoji indicator for the ratio column (mirrors AirspeedVelocity PR #140).
+ratio > 1  ⇒  head is faster than base
+ratio < 1  ⇒  head is slower than base
+"""
+function ratio_emoji(ratio::Float64, ratio_err::Float64, mode::Symbol)
+    if mode === :time && isfinite(ratio_err)
+        ratio + ratio_err < 0.8  && return " 🐢"   # significant slowdown
+        ratio - ratio_err > 1.2  && return " 🚀"   # significant speedup
+    else
+        ratio < 0.5              && return " 🐢"   # head uses >2× more memory
+        ratio > 1.5              && return " 🚀"   # head uses >1.5× less memory
+    end
+    return ""
+end
+
+function format_ratio(ratio::Float64, ratio_err::Float64, mode::Symbol)
+    emoji = ratio_emoji(ratio, ratio_err, mode)
+    if !isfinite(ratio)
+        return "N/A$emoji"
+    end
+    if isfinite(ratio_err) && ratio_err > 0
+        return @sprintf("%.3g ± %.2g%s", ratio, ratio_err, emoji)
+    else
+        return @sprintf("%.3g%s", ratio, emoji)
+    end
+end
+
+# ---- markdown table --------------------------------------------------------
+
+function markdown_table(; header::AbstractVector, data::AbstractMatrix)
+    @assert size(data, 2) == length(header)
+    cw = [max(length(h), 4) for h in header]
+    for row in eachrow(data)
+        for (i, v) in enumerate(row)
+            cw[i] = max(cw[i], length(string(v)))
+        end
+    end
+    io = IOBuffer()
+    print(io, "|")
+    for (i, h) in enumerate(header)
+        print(io, " $(rpad(h, cw[i])) |")
+    end
+    println(io)
+    print(io, "|:$(repeat('-', cw[1]))|")
+    for i in 2:length(header)
+        print(io, ":$(repeat('-', cw[i]-1)):|")
+    end
+    println(io)
+    for row in eachrow(data)
+        print(io, "|")
+        for (i, v) in enumerate(row)
+            s = string(v)
+            print(io, " $(rpad(s, cw[i])) |")
+        end
+        println(io)
+    end
+    return String(take!(io))
+end
+
+"""
+Build one markdown table (either :time or :memory) comparing `base_flat` and
+`head_flat`.  Keys present in only one revision are still shown with "—" in
+the missing column.
+"""
+function build_table(
+    base_flat::Dict{String,BenchmarkTools.Trial},
+    head_flat::Dict{String,BenchmarkTools.Trial},
+    mode::Symbol,
+    base_label::String,
+    head_label::String,
+)
+    all_keys = sort(collect(union(keys(base_flat), keys(head_flat))))
+    header = ["Benchmark", base_label, head_label, "Ratio (base/head)"]
+
+    rows = Vector{String}[]
+    for k in all_keys
+        has_base = haskey(base_flat, k)
+        has_head = haskey(head_flat, k)
+        b_str = has_base ? (mode === :time ? format_time(base_flat[k]) : format_memory(base_flat[k])) : "—"
+        h_str = has_head ? (mode === :time ? format_time(head_flat[k]) : format_memory(head_flat[k])) : "—"
+        ratio_str = if has_base && has_head
+            ratio, ratio_err = compute_ratio(base_flat[k], head_flat[k], mode)
+            format_ratio(ratio, ratio_err, mode)
+        else
+            "—"
+        end
+        push!(rows, [k, b_str, h_str, ratio_str])
+    end
+
+    data = isempty(rows) ? reshape(String[], 0, 4) : reduce(vcat, permutedims.(rows))
+    return markdown_table(; header, data)
+end
+
+# ---------------------------------------------------------------------------
+# Comment body assembly
+# ---------------------------------------------------------------------------
+
+function build_body(
+    base_flat::Dict{String,BenchmarkTools.Trial},
+    head_flat::Dict{String,BenchmarkTools.Trial},
+    base_label::String,
+    head_label::String,
+    julia_version::String,
+)
+    time_table   = build_table(base_flat, head_flat, :time,   base_label, head_label)
+    memory_table = build_table(base_flat, head_flat, :memory, base_label, head_label)
+
+    return """
+## Benchmark Results (Julia v$(julia_version))
+
+<details open>
+<summary>Time benchmarks</summary>
+
+$(time_table)
+</details>
+
+<details>
+<summary>Memory benchmarks</summary>
+
+$(memory_table)
+</details>
+
+> **Ratio interpretation:** values > 1 mean the PR is faster; values < 1 mean slower.
+> 🚀 significant speedup · 🐢 significant slowdown
+"""
+end
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+function main(argv = ARGS)
+    opts = parse_args_local(argv)
+    base_dir     = opts["base-dir"]
+    head_dir     = opts["head-dir"]
+    output_dir   = opts["output-dir"]
+    pr_number    = opts["pr"]
+    julia_version = opts["julia-version"]
+
+    mkpath(output_dir)
+
+    base_result_path = joinpath(output_dir, "results_base.jls")
+    head_result_path = joinpath(output_dir, "results_head.jls")
+
+    run_suite(base_dir, base_result_path)
+    run_suite(head_dir, head_result_path)
+
+    @info "Loading results …"
+    base_results = Serialization.deserialize(base_result_path)
+    head_results = Serialization.deserialize(head_result_path)
+
+    base_flat = flatten_group(base_results)
+    head_flat = flatten_group(head_results)
+
+    # Use short SHA labels when directories carry them; otherwise use directory names.
+    base_label = basename(rstrip(base_dir, '/'))
+    head_label = basename(rstrip(head_dir, '/'))
+
+    body = build_body(base_flat, head_flat, base_label, head_label, julia_version)
+
+    write(joinpath(output_dir, "body.md"), body)
+    write(joinpath(output_dir, "pr_number.txt"), pr_number)
+    write(joinpath(output_dir, "julia_version.txt"), julia_version)
+
+    @info "Benchmark comparison written to $(output_dir)/body.md"
+end
+
+main()

--- a/benchmark/compare.jl
+++ b/benchmark/compare.jl
@@ -77,14 +77,13 @@ function run_suite(repo_dir::AbstractString, result_path::AbstractString)
     Pkg.activate($(repr(bench_project)); io = devnull)
     Pkg.instantiate(; io = devnull)
     include($(repr(bench_script)))
-    BenchmarkTools.tune!(SUITE)
-    results = BenchmarkTools.run(SUITE; verbose = false)
+    results = BenchmarkTools.run(SUITE; verbose = true)
     using Serialization
     Serialization.serialize($(repr(result_path)), results)
     """
 
     cmd = `$(Base.julia_cmd()) --startup-file=no --project=$(bench_project) -e $(runner)`
-    @info "Running benchmarks at $repo_dir …"
+    @info "Running benchmarks at $repo_dir"
     run(cmd)
     return result_path
 end
@@ -274,6 +273,60 @@ function build_table(
 end
 
 # ---------------------------------------------------------------------------
+# Summary line
+# ---------------------------------------------------------------------------
+
+function build_summary(
+    base_flat::Dict{String,BenchmarkTools.Trial},
+    head_flat::Dict{String,BenchmarkTools.Trial},
+)
+    common = intersect(keys(base_flat), keys(head_flat))
+
+    time_speedups   = 0
+    time_regressions = 0
+    mem_improvements = 0
+    mem_regressions  = 0
+
+    for k in common
+        r_t, re_t = compute_ratio(base_flat[k], head_flat[k], :time)
+        if isfinite(r_t)
+            r_t - re_t > 1.2 && (time_speedups    += 1)
+            r_t + re_t < 0.8 && (time_regressions += 1)
+        end
+
+        r_m, _ = compute_ratio(base_flat[k], head_flat[k], :memory)
+        if isfinite(r_m)
+            r_m > 1.5 && (mem_improvements += 1)
+            r_m < 0.5 && (mem_regressions  += 1)
+        end
+    end
+
+    parts = String[]
+
+    if time_speedups > 0
+        n = time_speedups
+        push!(parts, "🚀 $n $(n == 1 ? "benchmark" : "benchmarks") improved in time")
+    end
+    if time_regressions > 0
+        n = time_regressions
+        push!(parts, "🐢 $n $(n == 1 ? "time regression" : "time regressions") detected")
+    end
+    if mem_improvements > 0
+        n = mem_improvements
+        push!(parts, "🚀 $n $(n == 1 ? "benchmark" : "benchmarks") use less memory")
+    end
+    if mem_regressions > 0
+        n = mem_regressions
+        push!(parts, "🐢 $n $(n == 1 ? "memory regression" : "memory regressions") detected")
+    end
+
+    if isempty(parts)
+        return "No significant performance or memory regressions detected."
+    end
+    return join(parts, " · ")
+end
+
+# ---------------------------------------------------------------------------
 # Comment body assembly
 # ---------------------------------------------------------------------------
 
@@ -286,9 +339,12 @@ function build_body(
 )
     time_table   = build_table(base_flat, head_flat, :time,   base_label, head_label)
     memory_table = build_table(base_flat, head_flat, :memory, base_label, head_label)
+    summary      = build_summary(base_flat, head_flat)
 
     return """
 ## Benchmark Results (Julia v$(julia_version))
+
+$(summary)
 
 <details open>
 <summary>Time benchmarks</summary>

--- a/benchmark/compare.jl
+++ b/benchmark/compare.jl
@@ -346,7 +346,7 @@ function build_body(
 
 $(summary)
 
-<details open>
+<details>
 <summary>Time benchmarks</summary>
 
 $(time_table)


### PR DESCRIPTION
Well, benchmarking appears to be a tough problem... The issue with AirspeedVelocity.jl and PkgBenchmark.jl is that neither seems to handle monorepos where subprojects depend on the main project. This PR replaces the current AirspeedVelocity-based benchmarking GitHub action with a custom one.

This custom solution does the following:
- `benchmark.yml` checks out master and the PR's branch into two different directories
- `compare.jl` runs benchmarks in both folders, compares their results, and renders a markdown post
- `benchmark.yml` uploads this markdown file along with some metadata files (a file holding the PR number, and another that holds the Julia version) to GitHub as an artifact
- `post_benchmark_comment.yml` downloads this artifact and creates a comment from it or updates the existing one

It is an improvement in the sense that it works in cases where a PR changes the code of a subpackage, and it implements the two changes I want to push into AirspeedVelocity (safe comment creation when a PR comes from a fork: https://github.com/MilesCranmer/AirspeedVelocity.jl/pull/142 and emojis to make it easy to find significant regressions and improvements: https://github.com/MilesCranmer/AirspeedVelocity.jl/pull/140).

On the other hand, I know that custom solutions should be avoided in general due to their maintenance costs, but I currently see no other option to meet the needs of this project.

Here is an example of how it looks in action: https://github.com/hakkelt/AbstractOperators.jl/pull/4